### PR TITLE
feat(executor): ✨ embed executor bundle in Go binary

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -74,9 +74,18 @@ tasks:
   go:build:
     desc: Build Go module
     aliases: [go:b]
+    deps: [executor:bundle]
     dir: quarry
     cmds:
       - go build -o quarry ./cmd/quarry
+
+  executor:bundle:
+    desc: Bundle executor for embedding
+    deps: [ts:build]
+    cmds:
+      - pnpm -C executor-node run bundle
+      - mkdir -p quarry/executor/bundle
+      - cp executor-node/dist/bundle/executor.mjs quarry/executor/bundle/
 
   go:lint:
     desc: Lint Go module

--- a/executor-node/package.json
+++ b/executor-node/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x dist/bin/executor.js",
+    "bundle": "mkdir -p dist/bundle && tsx scripts/bundle.ts && chmod +x dist/bundle/executor.mjs",
     "lint": "biome check .",
     "format": "biome check --write .",
     "typecheck": "tsc --noEmit",
@@ -23,6 +24,7 @@
     "puppeteer": "^24"
   },
   "devDependencies": {
+    "esbuild": "^0.27.2",
     "puppeteer": "^24.36.1"
   }
 }

--- a/executor-node/scripts/bundle.ts
+++ b/executor-node/scripts/bundle.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env tsx
+/**
+ * Bundle the executor into a standalone ESM file for embedding in the Go binary.
+ *
+ * This bundles:
+ * - Executor code
+ * - SDK (@justapithecus/quarry-sdk)
+ * - msgpack (@msgpack/msgpack)
+ *
+ * External (not bundled):
+ * - puppeteer (peer dependency, user must install)
+ * - Node built-ins
+ */
+import * as esbuild from 'esbuild'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = join(__dirname, '..')
+
+// Read version from quarry/types/version.go for embedding
+function getQuarryVersion(): string {
+  const versionFile = join(root, '..', 'quarry', 'types', 'version.go')
+  try {
+    const content = readFileSync(versionFile, 'utf-8')
+    const match = content.match(/const Version = "([^"]+)"/)
+    if (match) {
+      return match[1]
+    }
+  } catch {
+    // Ignore
+  }
+  return '0.0.0-unknown'
+}
+
+async function bundle() {
+  const version = getQuarryVersion()
+  console.log(`Bundling executor v${version}...`)
+
+  const result = await esbuild.build({
+    entryPoints: [join(root, 'src', 'bin', 'executor.ts')],
+    bundle: true,
+    platform: 'node',
+    target: 'node22',
+    format: 'esm',
+    outfile: join(root, 'dist', 'bundle', 'executor.mjs'),
+    external: ['puppeteer'], // Peer dependency
+    minify: false, // Keep readable for debugging
+    sourcemap: false, // No sourcemaps in embedded bundle
+    banner: {
+      js: `// Quarry Executor Bundle v${version}
+// This is a bundled version for embedding in the quarry binary.
+// Do not edit directly - regenerate with: pnpm run bundle
+`
+    },
+    define: {
+      'process.env.QUARRY_EXECUTOR_VERSION': JSON.stringify(version)
+    },
+    metafile: true
+  })
+
+  // Write metafile for analysis
+  writeFileSync(
+    join(root, 'dist', 'bundle', 'meta.json'),
+    JSON.stringify(result.metafile, null, 2)
+  )
+
+  // Ensure bundle has exactly one shebang at the start for direct execution
+  const bundlePath = join(root, 'dist', 'bundle', 'executor.mjs')
+  let bundleContent = readFileSync(bundlePath, 'utf-8')
+  // Remove any shebangs that might be in the middle (from source)
+  bundleContent = bundleContent.replace(/^#!.*\n/gm, '')
+  // Add shebang at the very start
+  bundleContent = '#!/usr/bin/env node\n' + bundleContent
+  writeFileSync(bundlePath, bundleContent)
+
+  // Get bundle size
+  const stats = readFileSync(bundlePath)
+  const sizeKB = (stats.length / 1024).toFixed(1)
+
+  console.log(`Bundle created: dist/bundle/executor.mjs (${sizeKB} KB)`)
+  console.log(`Version: ${version}`)
+}
+
+bundle().catch((err) => {
+  console.error('Bundle failed:', err)
+  process.exit(1)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: ^3.0.0
         version: 3.1.3
     devDependencies:
+      esbuild:
+        specifier: ^0.27.2
+        version: 0.27.2
       puppeteer:
         specifier: ^24.36.1
         version: 24.36.1(typescript@5.9.3)

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,0 +1,2650 @@
+#!/usr/bin/env node
+// Quarry Executor Bundle v0.1.0
+// This is a bundled version for embedding in the quarry binary.
+// Do not edit directly - regenerate with: pnpm run bundle
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/utf8.cjs
+var require_utf8 = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/utf8.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.utf8Count = utf8Count;
+    exports.utf8EncodeJs = utf8EncodeJs;
+    exports.utf8EncodeTE = utf8EncodeTE;
+    exports.utf8Encode = utf8Encode;
+    exports.utf8DecodeJs = utf8DecodeJs;
+    exports.utf8DecodeTD = utf8DecodeTD;
+    exports.utf8Decode = utf8Decode;
+    function utf8Count(str) {
+      const strLength = str.length;
+      let byteLength = 0;
+      let pos = 0;
+      while (pos < strLength) {
+        let value = str.charCodeAt(pos++);
+        if ((value & 4294967168) === 0) {
+          byteLength++;
+          continue;
+        } else if ((value & 4294965248) === 0) {
+          byteLength += 2;
+        } else {
+          if (value >= 55296 && value <= 56319) {
+            if (pos < strLength) {
+              const extra = str.charCodeAt(pos);
+              if ((extra & 64512) === 56320) {
+                ++pos;
+                value = ((value & 1023) << 10) + (extra & 1023) + 65536;
+              }
+            }
+          }
+          if ((value & 4294901760) === 0) {
+            byteLength += 3;
+          } else {
+            byteLength += 4;
+          }
+        }
+      }
+      return byteLength;
+    }
+    function utf8EncodeJs(str, output, outputOffset) {
+      const strLength = str.length;
+      let offset = outputOffset;
+      let pos = 0;
+      while (pos < strLength) {
+        let value = str.charCodeAt(pos++);
+        if ((value & 4294967168) === 0) {
+          output[offset++] = value;
+          continue;
+        } else if ((value & 4294965248) === 0) {
+          output[offset++] = value >> 6 & 31 | 192;
+        } else {
+          if (value >= 55296 && value <= 56319) {
+            if (pos < strLength) {
+              const extra = str.charCodeAt(pos);
+              if ((extra & 64512) === 56320) {
+                ++pos;
+                value = ((value & 1023) << 10) + (extra & 1023) + 65536;
+              }
+            }
+          }
+          if ((value & 4294901760) === 0) {
+            output[offset++] = value >> 12 & 15 | 224;
+            output[offset++] = value >> 6 & 63 | 128;
+          } else {
+            output[offset++] = value >> 18 & 7 | 240;
+            output[offset++] = value >> 12 & 63 | 128;
+            output[offset++] = value >> 6 & 63 | 128;
+          }
+        }
+        output[offset++] = value & 63 | 128;
+      }
+    }
+    var sharedTextEncoder = new TextEncoder();
+    var TEXT_ENCODER_THRESHOLD = 50;
+    function utf8EncodeTE(str, output, outputOffset) {
+      sharedTextEncoder.encodeInto(str, output.subarray(outputOffset));
+    }
+    function utf8Encode(str, output, outputOffset) {
+      if (str.length > TEXT_ENCODER_THRESHOLD) {
+        utf8EncodeTE(str, output, outputOffset);
+      } else {
+        utf8EncodeJs(str, output, outputOffset);
+      }
+    }
+    var CHUNK_SIZE = 4096;
+    function utf8DecodeJs(bytes, inputOffset, byteLength) {
+      let offset = inputOffset;
+      const end = offset + byteLength;
+      const units = [];
+      let result = "";
+      while (offset < end) {
+        const byte1 = bytes[offset++];
+        if ((byte1 & 128) === 0) {
+          units.push(byte1);
+        } else if ((byte1 & 224) === 192) {
+          const byte2 = bytes[offset++] & 63;
+          units.push((byte1 & 31) << 6 | byte2);
+        } else if ((byte1 & 240) === 224) {
+          const byte2 = bytes[offset++] & 63;
+          const byte3 = bytes[offset++] & 63;
+          units.push((byte1 & 31) << 12 | byte2 << 6 | byte3);
+        } else if ((byte1 & 248) === 240) {
+          const byte2 = bytes[offset++] & 63;
+          const byte3 = bytes[offset++] & 63;
+          const byte4 = bytes[offset++] & 63;
+          let unit = (byte1 & 7) << 18 | byte2 << 12 | byte3 << 6 | byte4;
+          if (unit > 65535) {
+            unit -= 65536;
+            units.push(unit >>> 10 & 1023 | 55296);
+            unit = 56320 | unit & 1023;
+          }
+          units.push(unit);
+        } else {
+          units.push(byte1);
+        }
+        if (units.length >= CHUNK_SIZE) {
+          result += String.fromCharCode(...units);
+          units.length = 0;
+        }
+      }
+      if (units.length > 0) {
+        result += String.fromCharCode(...units);
+      }
+      return result;
+    }
+    var sharedTextDecoder = new TextDecoder();
+    var TEXT_DECODER_THRESHOLD = 200;
+    function utf8DecodeTD(bytes, inputOffset, byteLength) {
+      const stringBytes = bytes.subarray(inputOffset, inputOffset + byteLength);
+      return sharedTextDecoder.decode(stringBytes);
+    }
+    function utf8Decode(bytes, inputOffset, byteLength) {
+      if (byteLength > TEXT_DECODER_THRESHOLD) {
+        return utf8DecodeTD(bytes, inputOffset, byteLength);
+      } else {
+        return utf8DecodeJs(bytes, inputOffset, byteLength);
+      }
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/ExtData.cjs
+var require_ExtData = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/ExtData.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ExtData = void 0;
+    var ExtData = class {
+      type;
+      data;
+      constructor(type, data) {
+        this.type = type;
+        this.data = data;
+      }
+    };
+    exports.ExtData = ExtData;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/DecodeError.cjs
+var require_DecodeError = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/DecodeError.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.DecodeError = void 0;
+    var DecodeError = class _DecodeError extends Error {
+      constructor(message) {
+        super(message);
+        const proto = Object.create(_DecodeError.prototype);
+        Object.setPrototypeOf(this, proto);
+        Object.defineProperty(this, "name", {
+          configurable: true,
+          enumerable: false,
+          value: _DecodeError.name
+        });
+      }
+    };
+    exports.DecodeError = DecodeError;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/int.cjs
+var require_int = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/int.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.UINT32_MAX = void 0;
+    exports.setUint64 = setUint64;
+    exports.setInt64 = setInt64;
+    exports.getInt64 = getInt64;
+    exports.getUint64 = getUint64;
+    exports.UINT32_MAX = 4294967295;
+    function setUint64(view, offset, value) {
+      const high = value / 4294967296;
+      const low = value;
+      view.setUint32(offset, high);
+      view.setUint32(offset + 4, low);
+    }
+    function setInt64(view, offset, value) {
+      const high = Math.floor(value / 4294967296);
+      const low = value;
+      view.setUint32(offset, high);
+      view.setUint32(offset + 4, low);
+    }
+    function getInt64(view, offset) {
+      const high = view.getInt32(offset);
+      const low = view.getUint32(offset + 4);
+      return high * 4294967296 + low;
+    }
+    function getUint64(view, offset) {
+      const high = view.getUint32(offset);
+      const low = view.getUint32(offset + 4);
+      return high * 4294967296 + low;
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/timestamp.cjs
+var require_timestamp = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/timestamp.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.timestampExtension = exports.EXT_TIMESTAMP = void 0;
+    exports.encodeTimeSpecToTimestamp = encodeTimeSpecToTimestamp;
+    exports.encodeDateToTimeSpec = encodeDateToTimeSpec;
+    exports.encodeTimestampExtension = encodeTimestampExtension;
+    exports.decodeTimestampToTimeSpec = decodeTimestampToTimeSpec;
+    exports.decodeTimestampExtension = decodeTimestampExtension;
+    var DecodeError_ts_1 = require_DecodeError();
+    var int_ts_1 = require_int();
+    exports.EXT_TIMESTAMP = -1;
+    var TIMESTAMP32_MAX_SEC = 4294967296 - 1;
+    var TIMESTAMP64_MAX_SEC = 17179869184 - 1;
+    function encodeTimeSpecToTimestamp({ sec, nsec }) {
+      if (sec >= 0 && nsec >= 0 && sec <= TIMESTAMP64_MAX_SEC) {
+        if (nsec === 0 && sec <= TIMESTAMP32_MAX_SEC) {
+          const rv = new Uint8Array(4);
+          const view = new DataView(rv.buffer);
+          view.setUint32(0, sec);
+          return rv;
+        } else {
+          const secHigh = sec / 4294967296;
+          const secLow = sec & 4294967295;
+          const rv = new Uint8Array(8);
+          const view = new DataView(rv.buffer);
+          view.setUint32(0, nsec << 2 | secHigh & 3);
+          view.setUint32(4, secLow);
+          return rv;
+        }
+      } else {
+        const rv = new Uint8Array(12);
+        const view = new DataView(rv.buffer);
+        view.setUint32(0, nsec);
+        (0, int_ts_1.setInt64)(view, 4, sec);
+        return rv;
+      }
+    }
+    function encodeDateToTimeSpec(date) {
+      const msec = date.getTime();
+      const sec = Math.floor(msec / 1e3);
+      const nsec = (msec - sec * 1e3) * 1e6;
+      const nsecInSec = Math.floor(nsec / 1e9);
+      return {
+        sec: sec + nsecInSec,
+        nsec: nsec - nsecInSec * 1e9
+      };
+    }
+    function encodeTimestampExtension(object) {
+      if (object instanceof Date) {
+        const timeSpec = encodeDateToTimeSpec(object);
+        return encodeTimeSpecToTimestamp(timeSpec);
+      } else {
+        return null;
+      }
+    }
+    function decodeTimestampToTimeSpec(data) {
+      const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+      switch (data.byteLength) {
+        case 4: {
+          const sec = view.getUint32(0);
+          const nsec = 0;
+          return { sec, nsec };
+        }
+        case 8: {
+          const nsec30AndSecHigh2 = view.getUint32(0);
+          const secLow32 = view.getUint32(4);
+          const sec = (nsec30AndSecHigh2 & 3) * 4294967296 + secLow32;
+          const nsec = nsec30AndSecHigh2 >>> 2;
+          return { sec, nsec };
+        }
+        case 12: {
+          const sec = (0, int_ts_1.getInt64)(view, 4);
+          const nsec = view.getUint32(0);
+          return { sec, nsec };
+        }
+        default:
+          throw new DecodeError_ts_1.DecodeError(`Unrecognized data size for timestamp (expected 4, 8, or 12): ${data.length}`);
+      }
+    }
+    function decodeTimestampExtension(data) {
+      const timeSpec = decodeTimestampToTimeSpec(data);
+      return new Date(timeSpec.sec * 1e3 + timeSpec.nsec / 1e6);
+    }
+    exports.timestampExtension = {
+      type: exports.EXT_TIMESTAMP,
+      encode: encodeTimestampExtension,
+      decode: decodeTimestampExtension
+    };
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/ExtensionCodec.cjs
+var require_ExtensionCodec = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/ExtensionCodec.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ExtensionCodec = void 0;
+    var ExtData_ts_1 = require_ExtData();
+    var timestamp_ts_1 = require_timestamp();
+    var ExtensionCodec = class _ExtensionCodec {
+      static defaultCodec = new _ExtensionCodec();
+      // ensures ExtensionCodecType<X> matches ExtensionCodec<X>
+      // this will make type errors a lot more clear
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      __brand;
+      // built-in extensions
+      builtInEncoders = [];
+      builtInDecoders = [];
+      // custom extensions
+      encoders = [];
+      decoders = [];
+      constructor() {
+        this.register(timestamp_ts_1.timestampExtension);
+      }
+      register({ type, encode, decode }) {
+        if (type >= 0) {
+          this.encoders[type] = encode;
+          this.decoders[type] = decode;
+        } else {
+          const index = -1 - type;
+          this.builtInEncoders[index] = encode;
+          this.builtInDecoders[index] = decode;
+        }
+      }
+      tryToEncode(object, context) {
+        for (let i = 0; i < this.builtInEncoders.length; i++) {
+          const encodeExt = this.builtInEncoders[i];
+          if (encodeExt != null) {
+            const data = encodeExt(object, context);
+            if (data != null) {
+              const type = -1 - i;
+              return new ExtData_ts_1.ExtData(type, data);
+            }
+          }
+        }
+        for (let i = 0; i < this.encoders.length; i++) {
+          const encodeExt = this.encoders[i];
+          if (encodeExt != null) {
+            const data = encodeExt(object, context);
+            if (data != null) {
+              const type = i;
+              return new ExtData_ts_1.ExtData(type, data);
+            }
+          }
+        }
+        if (object instanceof ExtData_ts_1.ExtData) {
+          return object;
+        }
+        return null;
+      }
+      decode(data, type, context) {
+        const decodeExt = type < 0 ? this.builtInDecoders[-1 - type] : this.decoders[type];
+        if (decodeExt) {
+          return decodeExt(data, type, context);
+        } else {
+          return new ExtData_ts_1.ExtData(type, data);
+        }
+      }
+    };
+    exports.ExtensionCodec = ExtensionCodec;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/typedArrays.cjs
+var require_typedArrays = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/typedArrays.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ensureUint8Array = ensureUint8Array;
+    function isArrayBufferLike(buffer) {
+      return buffer instanceof ArrayBuffer || typeof SharedArrayBuffer !== "undefined" && buffer instanceof SharedArrayBuffer;
+    }
+    function ensureUint8Array(buffer) {
+      if (buffer instanceof Uint8Array) {
+        return buffer;
+      } else if (ArrayBuffer.isView(buffer)) {
+        return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      } else if (isArrayBufferLike(buffer)) {
+        return new Uint8Array(buffer);
+      } else {
+        return Uint8Array.from(buffer);
+      }
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/Encoder.cjs
+var require_Encoder = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/Encoder.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Encoder = exports.DEFAULT_INITIAL_BUFFER_SIZE = exports.DEFAULT_MAX_DEPTH = void 0;
+    var utf8_ts_1 = require_utf8();
+    var ExtensionCodec_ts_1 = require_ExtensionCodec();
+    var int_ts_1 = require_int();
+    var typedArrays_ts_1 = require_typedArrays();
+    exports.DEFAULT_MAX_DEPTH = 100;
+    exports.DEFAULT_INITIAL_BUFFER_SIZE = 2048;
+    var Encoder = class _Encoder {
+      extensionCodec;
+      context;
+      useBigInt64;
+      maxDepth;
+      initialBufferSize;
+      sortKeys;
+      forceFloat32;
+      ignoreUndefined;
+      forceIntegerToFloat;
+      pos;
+      view;
+      bytes;
+      entered = false;
+      constructor(options) {
+        this.extensionCodec = options?.extensionCodec ?? ExtensionCodec_ts_1.ExtensionCodec.defaultCodec;
+        this.context = options?.context;
+        this.useBigInt64 = options?.useBigInt64 ?? false;
+        this.maxDepth = options?.maxDepth ?? exports.DEFAULT_MAX_DEPTH;
+        this.initialBufferSize = options?.initialBufferSize ?? exports.DEFAULT_INITIAL_BUFFER_SIZE;
+        this.sortKeys = options?.sortKeys ?? false;
+        this.forceFloat32 = options?.forceFloat32 ?? false;
+        this.ignoreUndefined = options?.ignoreUndefined ?? false;
+        this.forceIntegerToFloat = options?.forceIntegerToFloat ?? false;
+        this.pos = 0;
+        this.view = new DataView(new ArrayBuffer(this.initialBufferSize));
+        this.bytes = new Uint8Array(this.view.buffer);
+      }
+      clone() {
+        return new _Encoder({
+          extensionCodec: this.extensionCodec,
+          context: this.context,
+          useBigInt64: this.useBigInt64,
+          maxDepth: this.maxDepth,
+          initialBufferSize: this.initialBufferSize,
+          sortKeys: this.sortKeys,
+          forceFloat32: this.forceFloat32,
+          ignoreUndefined: this.ignoreUndefined,
+          forceIntegerToFloat: this.forceIntegerToFloat
+        });
+      }
+      reinitializeState() {
+        this.pos = 0;
+      }
+      /**
+       * This is almost equivalent to {@link Encoder#encode}, but it returns an reference of the encoder's internal buffer and thus much faster than {@link Encoder#encode}.
+       *
+       * @returns Encodes the object and returns a shared reference the encoder's internal buffer.
+       */
+      encodeSharedRef(object) {
+        if (this.entered) {
+          const instance = this.clone();
+          return instance.encodeSharedRef(object);
+        }
+        try {
+          this.entered = true;
+          this.reinitializeState();
+          this.doEncode(object, 1);
+          return this.bytes.subarray(0, this.pos);
+        } finally {
+          this.entered = false;
+        }
+      }
+      /**
+       * @returns Encodes the object and returns a copy of the encoder's internal buffer.
+       */
+      encode(object) {
+        if (this.entered) {
+          const instance = this.clone();
+          return instance.encode(object);
+        }
+        try {
+          this.entered = true;
+          this.reinitializeState();
+          this.doEncode(object, 1);
+          return this.bytes.slice(0, this.pos);
+        } finally {
+          this.entered = false;
+        }
+      }
+      doEncode(object, depth) {
+        if (depth > this.maxDepth) {
+          throw new Error(`Too deep objects in depth ${depth}`);
+        }
+        if (object == null) {
+          this.encodeNil();
+        } else if (typeof object === "boolean") {
+          this.encodeBoolean(object);
+        } else if (typeof object === "number") {
+          if (!this.forceIntegerToFloat) {
+            this.encodeNumber(object);
+          } else {
+            this.encodeNumberAsFloat(object);
+          }
+        } else if (typeof object === "string") {
+          this.encodeString(object);
+        } else if (this.useBigInt64 && typeof object === "bigint") {
+          this.encodeBigInt64(object);
+        } else {
+          this.encodeObject(object, depth);
+        }
+      }
+      ensureBufferSizeToWrite(sizeToWrite) {
+        const requiredSize = this.pos + sizeToWrite;
+        if (this.view.byteLength < requiredSize) {
+          this.resizeBuffer(requiredSize * 2);
+        }
+      }
+      resizeBuffer(newSize) {
+        const newBuffer = new ArrayBuffer(newSize);
+        const newBytes = new Uint8Array(newBuffer);
+        const newView = new DataView(newBuffer);
+        newBytes.set(this.bytes);
+        this.view = newView;
+        this.bytes = newBytes;
+      }
+      encodeNil() {
+        this.writeU8(192);
+      }
+      encodeBoolean(object) {
+        if (object === false) {
+          this.writeU8(194);
+        } else {
+          this.writeU8(195);
+        }
+      }
+      encodeNumber(object) {
+        if (!this.forceIntegerToFloat && Number.isSafeInteger(object)) {
+          if (object >= 0) {
+            if (object < 128) {
+              this.writeU8(object);
+            } else if (object < 256) {
+              this.writeU8(204);
+              this.writeU8(object);
+            } else if (object < 65536) {
+              this.writeU8(205);
+              this.writeU16(object);
+            } else if (object < 4294967296) {
+              this.writeU8(206);
+              this.writeU32(object);
+            } else if (!this.useBigInt64) {
+              this.writeU8(207);
+              this.writeU64(object);
+            } else {
+              this.encodeNumberAsFloat(object);
+            }
+          } else {
+            if (object >= -32) {
+              this.writeU8(224 | object + 32);
+            } else if (object >= -128) {
+              this.writeU8(208);
+              this.writeI8(object);
+            } else if (object >= -32768) {
+              this.writeU8(209);
+              this.writeI16(object);
+            } else if (object >= -2147483648) {
+              this.writeU8(210);
+              this.writeI32(object);
+            } else if (!this.useBigInt64) {
+              this.writeU8(211);
+              this.writeI64(object);
+            } else {
+              this.encodeNumberAsFloat(object);
+            }
+          }
+        } else {
+          this.encodeNumberAsFloat(object);
+        }
+      }
+      encodeNumberAsFloat(object) {
+        if (this.forceFloat32) {
+          this.writeU8(202);
+          this.writeF32(object);
+        } else {
+          this.writeU8(203);
+          this.writeF64(object);
+        }
+      }
+      encodeBigInt64(object) {
+        if (object >= BigInt(0)) {
+          this.writeU8(207);
+          this.writeBigUint64(object);
+        } else {
+          this.writeU8(211);
+          this.writeBigInt64(object);
+        }
+      }
+      writeStringHeader(byteLength) {
+        if (byteLength < 32) {
+          this.writeU8(160 + byteLength);
+        } else if (byteLength < 256) {
+          this.writeU8(217);
+          this.writeU8(byteLength);
+        } else if (byteLength < 65536) {
+          this.writeU8(218);
+          this.writeU16(byteLength);
+        } else if (byteLength < 4294967296) {
+          this.writeU8(219);
+          this.writeU32(byteLength);
+        } else {
+          throw new Error(`Too long string: ${byteLength} bytes in UTF-8`);
+        }
+      }
+      encodeString(object) {
+        const maxHeaderSize = 1 + 4;
+        const byteLength = (0, utf8_ts_1.utf8Count)(object);
+        this.ensureBufferSizeToWrite(maxHeaderSize + byteLength);
+        this.writeStringHeader(byteLength);
+        (0, utf8_ts_1.utf8Encode)(object, this.bytes, this.pos);
+        this.pos += byteLength;
+      }
+      encodeObject(object, depth) {
+        const ext = this.extensionCodec.tryToEncode(object, this.context);
+        if (ext != null) {
+          this.encodeExtension(ext);
+        } else if (Array.isArray(object)) {
+          this.encodeArray(object, depth);
+        } else if (ArrayBuffer.isView(object)) {
+          this.encodeBinary(object);
+        } else if (typeof object === "object") {
+          this.encodeMap(object, depth);
+        } else {
+          throw new Error(`Unrecognized object: ${Object.prototype.toString.apply(object)}`);
+        }
+      }
+      encodeBinary(object) {
+        const size = object.byteLength;
+        if (size < 256) {
+          this.writeU8(196);
+          this.writeU8(size);
+        } else if (size < 65536) {
+          this.writeU8(197);
+          this.writeU16(size);
+        } else if (size < 4294967296) {
+          this.writeU8(198);
+          this.writeU32(size);
+        } else {
+          throw new Error(`Too large binary: ${size}`);
+        }
+        const bytes = (0, typedArrays_ts_1.ensureUint8Array)(object);
+        this.writeU8a(bytes);
+      }
+      encodeArray(object, depth) {
+        const size = object.length;
+        if (size < 16) {
+          this.writeU8(144 + size);
+        } else if (size < 65536) {
+          this.writeU8(220);
+          this.writeU16(size);
+        } else if (size < 4294967296) {
+          this.writeU8(221);
+          this.writeU32(size);
+        } else {
+          throw new Error(`Too large array: ${size}`);
+        }
+        for (const item of object) {
+          this.doEncode(item, depth + 1);
+        }
+      }
+      countWithoutUndefined(object, keys) {
+        let count = 0;
+        for (const key of keys) {
+          if (object[key] !== void 0) {
+            count++;
+          }
+        }
+        return count;
+      }
+      encodeMap(object, depth) {
+        const keys = Object.keys(object);
+        if (this.sortKeys) {
+          keys.sort();
+        }
+        const size = this.ignoreUndefined ? this.countWithoutUndefined(object, keys) : keys.length;
+        if (size < 16) {
+          this.writeU8(128 + size);
+        } else if (size < 65536) {
+          this.writeU8(222);
+          this.writeU16(size);
+        } else if (size < 4294967296) {
+          this.writeU8(223);
+          this.writeU32(size);
+        } else {
+          throw new Error(`Too large map object: ${size}`);
+        }
+        for (const key of keys) {
+          const value = object[key];
+          if (!(this.ignoreUndefined && value === void 0)) {
+            this.encodeString(key);
+            this.doEncode(value, depth + 1);
+          }
+        }
+      }
+      encodeExtension(ext) {
+        if (typeof ext.data === "function") {
+          const data = ext.data(this.pos + 6);
+          const size2 = data.length;
+          if (size2 >= 4294967296) {
+            throw new Error(`Too large extension object: ${size2}`);
+          }
+          this.writeU8(201);
+          this.writeU32(size2);
+          this.writeI8(ext.type);
+          this.writeU8a(data);
+          return;
+        }
+        const size = ext.data.length;
+        if (size === 1) {
+          this.writeU8(212);
+        } else if (size === 2) {
+          this.writeU8(213);
+        } else if (size === 4) {
+          this.writeU8(214);
+        } else if (size === 8) {
+          this.writeU8(215);
+        } else if (size === 16) {
+          this.writeU8(216);
+        } else if (size < 256) {
+          this.writeU8(199);
+          this.writeU8(size);
+        } else if (size < 65536) {
+          this.writeU8(200);
+          this.writeU16(size);
+        } else if (size < 4294967296) {
+          this.writeU8(201);
+          this.writeU32(size);
+        } else {
+          throw new Error(`Too large extension object: ${size}`);
+        }
+        this.writeI8(ext.type);
+        this.writeU8a(ext.data);
+      }
+      writeU8(value) {
+        this.ensureBufferSizeToWrite(1);
+        this.view.setUint8(this.pos, value);
+        this.pos++;
+      }
+      writeU8a(values) {
+        const size = values.length;
+        this.ensureBufferSizeToWrite(size);
+        this.bytes.set(values, this.pos);
+        this.pos += size;
+      }
+      writeI8(value) {
+        this.ensureBufferSizeToWrite(1);
+        this.view.setInt8(this.pos, value);
+        this.pos++;
+      }
+      writeU16(value) {
+        this.ensureBufferSizeToWrite(2);
+        this.view.setUint16(this.pos, value);
+        this.pos += 2;
+      }
+      writeI16(value) {
+        this.ensureBufferSizeToWrite(2);
+        this.view.setInt16(this.pos, value);
+        this.pos += 2;
+      }
+      writeU32(value) {
+        this.ensureBufferSizeToWrite(4);
+        this.view.setUint32(this.pos, value);
+        this.pos += 4;
+      }
+      writeI32(value) {
+        this.ensureBufferSizeToWrite(4);
+        this.view.setInt32(this.pos, value);
+        this.pos += 4;
+      }
+      writeF32(value) {
+        this.ensureBufferSizeToWrite(4);
+        this.view.setFloat32(this.pos, value);
+        this.pos += 4;
+      }
+      writeF64(value) {
+        this.ensureBufferSizeToWrite(8);
+        this.view.setFloat64(this.pos, value);
+        this.pos += 8;
+      }
+      writeU64(value) {
+        this.ensureBufferSizeToWrite(8);
+        (0, int_ts_1.setUint64)(this.view, this.pos, value);
+        this.pos += 8;
+      }
+      writeI64(value) {
+        this.ensureBufferSizeToWrite(8);
+        (0, int_ts_1.setInt64)(this.view, this.pos, value);
+        this.pos += 8;
+      }
+      writeBigUint64(value) {
+        this.ensureBufferSizeToWrite(8);
+        this.view.setBigUint64(this.pos, value);
+        this.pos += 8;
+      }
+      writeBigInt64(value) {
+        this.ensureBufferSizeToWrite(8);
+        this.view.setBigInt64(this.pos, value);
+        this.pos += 8;
+      }
+    };
+    exports.Encoder = Encoder;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/encode.cjs
+var require_encode = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/encode.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.encode = encode;
+    var Encoder_ts_1 = require_Encoder();
+    function encode(value, options) {
+      const encoder = new Encoder_ts_1.Encoder(options);
+      return encoder.encodeSharedRef(value);
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/prettyByte.cjs
+var require_prettyByte = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/prettyByte.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.prettyByte = prettyByte;
+    function prettyByte(byte) {
+      return `${byte < 0 ? "-" : ""}0x${Math.abs(byte).toString(16).padStart(2, "0")}`;
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/CachedKeyDecoder.cjs
+var require_CachedKeyDecoder = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/CachedKeyDecoder.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.CachedKeyDecoder = void 0;
+    var utf8_ts_1 = require_utf8();
+    var DEFAULT_MAX_KEY_LENGTH = 16;
+    var DEFAULT_MAX_LENGTH_PER_KEY = 16;
+    var CachedKeyDecoder = class {
+      hit = 0;
+      miss = 0;
+      caches;
+      maxKeyLength;
+      maxLengthPerKey;
+      constructor(maxKeyLength = DEFAULT_MAX_KEY_LENGTH, maxLengthPerKey = DEFAULT_MAX_LENGTH_PER_KEY) {
+        this.maxKeyLength = maxKeyLength;
+        this.maxLengthPerKey = maxLengthPerKey;
+        this.caches = [];
+        for (let i = 0; i < this.maxKeyLength; i++) {
+          this.caches.push([]);
+        }
+      }
+      canBeCached(byteLength) {
+        return byteLength > 0 && byteLength <= this.maxKeyLength;
+      }
+      find(bytes, inputOffset, byteLength) {
+        const records = this.caches[byteLength - 1];
+        FIND_CHUNK: for (const record of records) {
+          const recordBytes = record.bytes;
+          for (let j = 0; j < byteLength; j++) {
+            if (recordBytes[j] !== bytes[inputOffset + j]) {
+              continue FIND_CHUNK;
+            }
+          }
+          return record.str;
+        }
+        return null;
+      }
+      store(bytes, value) {
+        const records = this.caches[bytes.length - 1];
+        const record = { bytes, str: value };
+        if (records.length >= this.maxLengthPerKey) {
+          records[Math.random() * records.length | 0] = record;
+        } else {
+          records.push(record);
+        }
+      }
+      decode(bytes, inputOffset, byteLength) {
+        const cachedValue = this.find(bytes, inputOffset, byteLength);
+        if (cachedValue != null) {
+          this.hit++;
+          return cachedValue;
+        }
+        this.miss++;
+        const str = (0, utf8_ts_1.utf8DecodeJs)(bytes, inputOffset, byteLength);
+        const slicedCopyOfBytes = Uint8Array.prototype.slice.call(bytes, inputOffset, inputOffset + byteLength);
+        this.store(slicedCopyOfBytes, str);
+        return str;
+      }
+    };
+    exports.CachedKeyDecoder = CachedKeyDecoder;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/Decoder.cjs
+var require_Decoder = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/Decoder.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Decoder = void 0;
+    var prettyByte_ts_1 = require_prettyByte();
+    var ExtensionCodec_ts_1 = require_ExtensionCodec();
+    var int_ts_1 = require_int();
+    var utf8_ts_1 = require_utf8();
+    var typedArrays_ts_1 = require_typedArrays();
+    var CachedKeyDecoder_ts_1 = require_CachedKeyDecoder();
+    var DecodeError_ts_1 = require_DecodeError();
+    var STATE_ARRAY = "array";
+    var STATE_MAP_KEY = "map_key";
+    var STATE_MAP_VALUE = "map_value";
+    var mapKeyConverter = (key) => {
+      if (typeof key === "string" || typeof key === "number") {
+        return key;
+      }
+      throw new DecodeError_ts_1.DecodeError("The type of key must be string or number but " + typeof key);
+    };
+    var StackPool = class {
+      stack = [];
+      stackHeadPosition = -1;
+      get length() {
+        return this.stackHeadPosition + 1;
+      }
+      top() {
+        return this.stack[this.stackHeadPosition];
+      }
+      pushArrayState(size) {
+        const state = this.getUninitializedStateFromPool();
+        state.type = STATE_ARRAY;
+        state.position = 0;
+        state.size = size;
+        state.array = new Array(size);
+      }
+      pushMapState(size) {
+        const state = this.getUninitializedStateFromPool();
+        state.type = STATE_MAP_KEY;
+        state.readCount = 0;
+        state.size = size;
+        state.map = {};
+      }
+      getUninitializedStateFromPool() {
+        this.stackHeadPosition++;
+        if (this.stackHeadPosition === this.stack.length) {
+          const partialState = {
+            type: void 0,
+            size: 0,
+            array: void 0,
+            position: 0,
+            readCount: 0,
+            map: void 0,
+            key: null
+          };
+          this.stack.push(partialState);
+        }
+        return this.stack[this.stackHeadPosition];
+      }
+      release(state) {
+        const topStackState = this.stack[this.stackHeadPosition];
+        if (topStackState !== state) {
+          throw new Error("Invalid stack state. Released state is not on top of the stack.");
+        }
+        if (state.type === STATE_ARRAY) {
+          const partialState = state;
+          partialState.size = 0;
+          partialState.array = void 0;
+          partialState.position = 0;
+          partialState.type = void 0;
+        }
+        if (state.type === STATE_MAP_KEY || state.type === STATE_MAP_VALUE) {
+          const partialState = state;
+          partialState.size = 0;
+          partialState.map = void 0;
+          partialState.readCount = 0;
+          partialState.type = void 0;
+        }
+        this.stackHeadPosition--;
+      }
+      reset() {
+        this.stack.length = 0;
+        this.stackHeadPosition = -1;
+      }
+    };
+    var HEAD_BYTE_REQUIRED = -1;
+    var EMPTY_VIEW = new DataView(new ArrayBuffer(0));
+    var EMPTY_BYTES = new Uint8Array(EMPTY_VIEW.buffer);
+    try {
+      EMPTY_VIEW.getInt8(0);
+    } catch (e) {
+      if (!(e instanceof RangeError)) {
+        throw new Error("This module is not supported in the current JavaScript engine because DataView does not throw RangeError on out-of-bounds access");
+      }
+    }
+    var MORE_DATA = new RangeError("Insufficient data");
+    var sharedCachedKeyDecoder = new CachedKeyDecoder_ts_1.CachedKeyDecoder();
+    var Decoder = class _Decoder {
+      extensionCodec;
+      context;
+      useBigInt64;
+      rawStrings;
+      maxStrLength;
+      maxBinLength;
+      maxArrayLength;
+      maxMapLength;
+      maxExtLength;
+      keyDecoder;
+      mapKeyConverter;
+      totalPos = 0;
+      pos = 0;
+      view = EMPTY_VIEW;
+      bytes = EMPTY_BYTES;
+      headByte = HEAD_BYTE_REQUIRED;
+      stack = new StackPool();
+      entered = false;
+      constructor(options) {
+        this.extensionCodec = options?.extensionCodec ?? ExtensionCodec_ts_1.ExtensionCodec.defaultCodec;
+        this.context = options?.context;
+        this.useBigInt64 = options?.useBigInt64 ?? false;
+        this.rawStrings = options?.rawStrings ?? false;
+        this.maxStrLength = options?.maxStrLength ?? int_ts_1.UINT32_MAX;
+        this.maxBinLength = options?.maxBinLength ?? int_ts_1.UINT32_MAX;
+        this.maxArrayLength = options?.maxArrayLength ?? int_ts_1.UINT32_MAX;
+        this.maxMapLength = options?.maxMapLength ?? int_ts_1.UINT32_MAX;
+        this.maxExtLength = options?.maxExtLength ?? int_ts_1.UINT32_MAX;
+        this.keyDecoder = options?.keyDecoder !== void 0 ? options.keyDecoder : sharedCachedKeyDecoder;
+        this.mapKeyConverter = options?.mapKeyConverter ?? mapKeyConverter;
+      }
+      clone() {
+        return new _Decoder({
+          extensionCodec: this.extensionCodec,
+          context: this.context,
+          useBigInt64: this.useBigInt64,
+          rawStrings: this.rawStrings,
+          maxStrLength: this.maxStrLength,
+          maxBinLength: this.maxBinLength,
+          maxArrayLength: this.maxArrayLength,
+          maxMapLength: this.maxMapLength,
+          maxExtLength: this.maxExtLength,
+          keyDecoder: this.keyDecoder
+        });
+      }
+      reinitializeState() {
+        this.totalPos = 0;
+        this.headByte = HEAD_BYTE_REQUIRED;
+        this.stack.reset();
+      }
+      setBuffer(buffer) {
+        const bytes = (0, typedArrays_ts_1.ensureUint8Array)(buffer);
+        this.bytes = bytes;
+        this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        this.pos = 0;
+      }
+      appendBuffer(buffer) {
+        if (this.headByte === HEAD_BYTE_REQUIRED && !this.hasRemaining(1)) {
+          this.setBuffer(buffer);
+        } else {
+          const remainingData = this.bytes.subarray(this.pos);
+          const newData = (0, typedArrays_ts_1.ensureUint8Array)(buffer);
+          const newBuffer = new Uint8Array(remainingData.length + newData.length);
+          newBuffer.set(remainingData);
+          newBuffer.set(newData, remainingData.length);
+          this.setBuffer(newBuffer);
+        }
+      }
+      hasRemaining(size) {
+        return this.view.byteLength - this.pos >= size;
+      }
+      createExtraByteError(posToShow) {
+        const { view, pos } = this;
+        return new RangeError(`Extra ${view.byteLength - pos} of ${view.byteLength} byte(s) found at buffer[${posToShow}]`);
+      }
+      /**
+       * @throws {@link DecodeError}
+       * @throws {@link RangeError}
+       */
+      decode(buffer) {
+        if (this.entered) {
+          const instance = this.clone();
+          return instance.decode(buffer);
+        }
+        try {
+          this.entered = true;
+          this.reinitializeState();
+          this.setBuffer(buffer);
+          const object = this.doDecodeSync();
+          if (this.hasRemaining(1)) {
+            throw this.createExtraByteError(this.pos);
+          }
+          return object;
+        } finally {
+          this.entered = false;
+        }
+      }
+      *decodeMulti(buffer) {
+        if (this.entered) {
+          const instance = this.clone();
+          yield* instance.decodeMulti(buffer);
+          return;
+        }
+        try {
+          this.entered = true;
+          this.reinitializeState();
+          this.setBuffer(buffer);
+          while (this.hasRemaining(1)) {
+            yield this.doDecodeSync();
+          }
+        } finally {
+          this.entered = false;
+        }
+      }
+      async decodeAsync(stream) {
+        if (this.entered) {
+          const instance = this.clone();
+          return instance.decodeAsync(stream);
+        }
+        try {
+          this.entered = true;
+          let decoded = false;
+          let object;
+          for await (const buffer of stream) {
+            if (decoded) {
+              this.entered = false;
+              throw this.createExtraByteError(this.totalPos);
+            }
+            this.appendBuffer(buffer);
+            try {
+              object = this.doDecodeSync();
+              decoded = true;
+            } catch (e) {
+              if (!(e instanceof RangeError)) {
+                throw e;
+              }
+            }
+            this.totalPos += this.pos;
+          }
+          if (decoded) {
+            if (this.hasRemaining(1)) {
+              throw this.createExtraByteError(this.totalPos);
+            }
+            return object;
+          }
+          const { headByte, pos, totalPos } = this;
+          throw new RangeError(`Insufficient data in parsing ${(0, prettyByte_ts_1.prettyByte)(headByte)} at ${totalPos} (${pos} in the current buffer)`);
+        } finally {
+          this.entered = false;
+        }
+      }
+      decodeArrayStream(stream) {
+        return this.decodeMultiAsync(stream, true);
+      }
+      decodeStream(stream) {
+        return this.decodeMultiAsync(stream, false);
+      }
+      async *decodeMultiAsync(stream, isArray) {
+        if (this.entered) {
+          const instance = this.clone();
+          yield* instance.decodeMultiAsync(stream, isArray);
+          return;
+        }
+        try {
+          this.entered = true;
+          let isArrayHeaderRequired = isArray;
+          let arrayItemsLeft = -1;
+          for await (const buffer of stream) {
+            if (isArray && arrayItemsLeft === 0) {
+              throw this.createExtraByteError(this.totalPos);
+            }
+            this.appendBuffer(buffer);
+            if (isArrayHeaderRequired) {
+              arrayItemsLeft = this.readArraySize();
+              isArrayHeaderRequired = false;
+              this.complete();
+            }
+            try {
+              while (true) {
+                yield this.doDecodeSync();
+                if (--arrayItemsLeft === 0) {
+                  break;
+                }
+              }
+            } catch (e) {
+              if (!(e instanceof RangeError)) {
+                throw e;
+              }
+            }
+            this.totalPos += this.pos;
+          }
+        } finally {
+          this.entered = false;
+        }
+      }
+      doDecodeSync() {
+        DECODE: while (true) {
+          const headByte = this.readHeadByte();
+          let object;
+          if (headByte >= 224) {
+            object = headByte - 256;
+          } else if (headByte < 192) {
+            if (headByte < 128) {
+              object = headByte;
+            } else if (headByte < 144) {
+              const size = headByte - 128;
+              if (size !== 0) {
+                this.pushMapState(size);
+                this.complete();
+                continue DECODE;
+              } else {
+                object = {};
+              }
+            } else if (headByte < 160) {
+              const size = headByte - 144;
+              if (size !== 0) {
+                this.pushArrayState(size);
+                this.complete();
+                continue DECODE;
+              } else {
+                object = [];
+              }
+            } else {
+              const byteLength = headByte - 160;
+              object = this.decodeString(byteLength, 0);
+            }
+          } else if (headByte === 192) {
+            object = null;
+          } else if (headByte === 194) {
+            object = false;
+          } else if (headByte === 195) {
+            object = true;
+          } else if (headByte === 202) {
+            object = this.readF32();
+          } else if (headByte === 203) {
+            object = this.readF64();
+          } else if (headByte === 204) {
+            object = this.readU8();
+          } else if (headByte === 205) {
+            object = this.readU16();
+          } else if (headByte === 206) {
+            object = this.readU32();
+          } else if (headByte === 207) {
+            if (this.useBigInt64) {
+              object = this.readU64AsBigInt();
+            } else {
+              object = this.readU64();
+            }
+          } else if (headByte === 208) {
+            object = this.readI8();
+          } else if (headByte === 209) {
+            object = this.readI16();
+          } else if (headByte === 210) {
+            object = this.readI32();
+          } else if (headByte === 211) {
+            if (this.useBigInt64) {
+              object = this.readI64AsBigInt();
+            } else {
+              object = this.readI64();
+            }
+          } else if (headByte === 217) {
+            const byteLength = this.lookU8();
+            object = this.decodeString(byteLength, 1);
+          } else if (headByte === 218) {
+            const byteLength = this.lookU16();
+            object = this.decodeString(byteLength, 2);
+          } else if (headByte === 219) {
+            const byteLength = this.lookU32();
+            object = this.decodeString(byteLength, 4);
+          } else if (headByte === 220) {
+            const size = this.readU16();
+            if (size !== 0) {
+              this.pushArrayState(size);
+              this.complete();
+              continue DECODE;
+            } else {
+              object = [];
+            }
+          } else if (headByte === 221) {
+            const size = this.readU32();
+            if (size !== 0) {
+              this.pushArrayState(size);
+              this.complete();
+              continue DECODE;
+            } else {
+              object = [];
+            }
+          } else if (headByte === 222) {
+            const size = this.readU16();
+            if (size !== 0) {
+              this.pushMapState(size);
+              this.complete();
+              continue DECODE;
+            } else {
+              object = {};
+            }
+          } else if (headByte === 223) {
+            const size = this.readU32();
+            if (size !== 0) {
+              this.pushMapState(size);
+              this.complete();
+              continue DECODE;
+            } else {
+              object = {};
+            }
+          } else if (headByte === 196) {
+            const size = this.lookU8();
+            object = this.decodeBinary(size, 1);
+          } else if (headByte === 197) {
+            const size = this.lookU16();
+            object = this.decodeBinary(size, 2);
+          } else if (headByte === 198) {
+            const size = this.lookU32();
+            object = this.decodeBinary(size, 4);
+          } else if (headByte === 212) {
+            object = this.decodeExtension(1, 0);
+          } else if (headByte === 213) {
+            object = this.decodeExtension(2, 0);
+          } else if (headByte === 214) {
+            object = this.decodeExtension(4, 0);
+          } else if (headByte === 215) {
+            object = this.decodeExtension(8, 0);
+          } else if (headByte === 216) {
+            object = this.decodeExtension(16, 0);
+          } else if (headByte === 199) {
+            const size = this.lookU8();
+            object = this.decodeExtension(size, 1);
+          } else if (headByte === 200) {
+            const size = this.lookU16();
+            object = this.decodeExtension(size, 2);
+          } else if (headByte === 201) {
+            const size = this.lookU32();
+            object = this.decodeExtension(size, 4);
+          } else {
+            throw new DecodeError_ts_1.DecodeError(`Unrecognized type byte: ${(0, prettyByte_ts_1.prettyByte)(headByte)}`);
+          }
+          this.complete();
+          const stack = this.stack;
+          while (stack.length > 0) {
+            const state = stack.top();
+            if (state.type === STATE_ARRAY) {
+              state.array[state.position] = object;
+              state.position++;
+              if (state.position === state.size) {
+                object = state.array;
+                stack.release(state);
+              } else {
+                continue DECODE;
+              }
+            } else if (state.type === STATE_MAP_KEY) {
+              if (object === "__proto__") {
+                throw new DecodeError_ts_1.DecodeError("The key __proto__ is not allowed");
+              }
+              state.key = this.mapKeyConverter(object);
+              state.type = STATE_MAP_VALUE;
+              continue DECODE;
+            } else {
+              state.map[state.key] = object;
+              state.readCount++;
+              if (state.readCount === state.size) {
+                object = state.map;
+                stack.release(state);
+              } else {
+                state.key = null;
+                state.type = STATE_MAP_KEY;
+                continue DECODE;
+              }
+            }
+          }
+          return object;
+        }
+      }
+      readHeadByte() {
+        if (this.headByte === HEAD_BYTE_REQUIRED) {
+          this.headByte = this.readU8();
+        }
+        return this.headByte;
+      }
+      complete() {
+        this.headByte = HEAD_BYTE_REQUIRED;
+      }
+      readArraySize() {
+        const headByte = this.readHeadByte();
+        switch (headByte) {
+          case 220:
+            return this.readU16();
+          case 221:
+            return this.readU32();
+          default: {
+            if (headByte < 160) {
+              return headByte - 144;
+            } else {
+              throw new DecodeError_ts_1.DecodeError(`Unrecognized array type byte: ${(0, prettyByte_ts_1.prettyByte)(headByte)}`);
+            }
+          }
+        }
+      }
+      pushMapState(size) {
+        if (size > this.maxMapLength) {
+          throw new DecodeError_ts_1.DecodeError(`Max length exceeded: map length (${size}) > maxMapLengthLength (${this.maxMapLength})`);
+        }
+        this.stack.pushMapState(size);
+      }
+      pushArrayState(size) {
+        if (size > this.maxArrayLength) {
+          throw new DecodeError_ts_1.DecodeError(`Max length exceeded: array length (${size}) > maxArrayLength (${this.maxArrayLength})`);
+        }
+        this.stack.pushArrayState(size);
+      }
+      decodeString(byteLength, headerOffset) {
+        if (!this.rawStrings || this.stateIsMapKey()) {
+          return this.decodeUtf8String(byteLength, headerOffset);
+        }
+        return this.decodeBinary(byteLength, headerOffset);
+      }
+      /**
+       * @throws {@link RangeError}
+       */
+      decodeUtf8String(byteLength, headerOffset) {
+        if (byteLength > this.maxStrLength) {
+          throw new DecodeError_ts_1.DecodeError(`Max length exceeded: UTF-8 byte length (${byteLength}) > maxStrLength (${this.maxStrLength})`);
+        }
+        if (this.bytes.byteLength < this.pos + headerOffset + byteLength) {
+          throw MORE_DATA;
+        }
+        const offset = this.pos + headerOffset;
+        let object;
+        if (this.stateIsMapKey() && this.keyDecoder?.canBeCached(byteLength)) {
+          object = this.keyDecoder.decode(this.bytes, offset, byteLength);
+        } else {
+          object = (0, utf8_ts_1.utf8Decode)(this.bytes, offset, byteLength);
+        }
+        this.pos += headerOffset + byteLength;
+        return object;
+      }
+      stateIsMapKey() {
+        if (this.stack.length > 0) {
+          const state = this.stack.top();
+          return state.type === STATE_MAP_KEY;
+        }
+        return false;
+      }
+      /**
+       * @throws {@link RangeError}
+       */
+      decodeBinary(byteLength, headOffset) {
+        if (byteLength > this.maxBinLength) {
+          throw new DecodeError_ts_1.DecodeError(`Max length exceeded: bin length (${byteLength}) > maxBinLength (${this.maxBinLength})`);
+        }
+        if (!this.hasRemaining(byteLength + headOffset)) {
+          throw MORE_DATA;
+        }
+        const offset = this.pos + headOffset;
+        const object = this.bytes.subarray(offset, offset + byteLength);
+        this.pos += headOffset + byteLength;
+        return object;
+      }
+      decodeExtension(size, headOffset) {
+        if (size > this.maxExtLength) {
+          throw new DecodeError_ts_1.DecodeError(`Max length exceeded: ext length (${size}) > maxExtLength (${this.maxExtLength})`);
+        }
+        const extType = this.view.getInt8(this.pos + headOffset);
+        const data = this.decodeBinary(
+          size,
+          headOffset + 1
+          /* extType */
+        );
+        return this.extensionCodec.decode(data, extType, this.context);
+      }
+      lookU8() {
+        return this.view.getUint8(this.pos);
+      }
+      lookU16() {
+        return this.view.getUint16(this.pos);
+      }
+      lookU32() {
+        return this.view.getUint32(this.pos);
+      }
+      readU8() {
+        const value = this.view.getUint8(this.pos);
+        this.pos++;
+        return value;
+      }
+      readI8() {
+        const value = this.view.getInt8(this.pos);
+        this.pos++;
+        return value;
+      }
+      readU16() {
+        const value = this.view.getUint16(this.pos);
+        this.pos += 2;
+        return value;
+      }
+      readI16() {
+        const value = this.view.getInt16(this.pos);
+        this.pos += 2;
+        return value;
+      }
+      readU32() {
+        const value = this.view.getUint32(this.pos);
+        this.pos += 4;
+        return value;
+      }
+      readI32() {
+        const value = this.view.getInt32(this.pos);
+        this.pos += 4;
+        return value;
+      }
+      readU64() {
+        const value = (0, int_ts_1.getUint64)(this.view, this.pos);
+        this.pos += 8;
+        return value;
+      }
+      readI64() {
+        const value = (0, int_ts_1.getInt64)(this.view, this.pos);
+        this.pos += 8;
+        return value;
+      }
+      readU64AsBigInt() {
+        const value = this.view.getBigUint64(this.pos);
+        this.pos += 8;
+        return value;
+      }
+      readI64AsBigInt() {
+        const value = this.view.getBigInt64(this.pos);
+        this.pos += 8;
+        return value;
+      }
+      readF32() {
+        const value = this.view.getFloat32(this.pos);
+        this.pos += 4;
+        return value;
+      }
+      readF64() {
+        const value = this.view.getFloat64(this.pos);
+        this.pos += 8;
+        return value;
+      }
+    };
+    exports.Decoder = Decoder;
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/decode.cjs
+var require_decode = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/decode.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.decode = decode;
+    exports.decodeMulti = decodeMulti;
+    var Decoder_ts_1 = require_Decoder();
+    function decode(buffer, options) {
+      const decoder = new Decoder_ts_1.Decoder(options);
+      return decoder.decode(buffer);
+    }
+    function decodeMulti(buffer, options) {
+      const decoder = new Decoder_ts_1.Decoder(options);
+      return decoder.decodeMulti(buffer);
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/stream.cjs
+var require_stream = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/utils/stream.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.isAsyncIterable = isAsyncIterable;
+    exports.asyncIterableFromStream = asyncIterableFromStream;
+    exports.ensureAsyncIterable = ensureAsyncIterable;
+    function isAsyncIterable(object) {
+      return object[Symbol.asyncIterator] != null;
+    }
+    async function* asyncIterableFromStream(stream) {
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            return;
+          }
+          yield value;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    function ensureAsyncIterable(streamLike) {
+      if (isAsyncIterable(streamLike)) {
+        return streamLike;
+      } else {
+        return asyncIterableFromStream(streamLike);
+      }
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/decodeAsync.cjs
+var require_decodeAsync = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/decodeAsync.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.decodeAsync = decodeAsync;
+    exports.decodeArrayStream = decodeArrayStream;
+    exports.decodeMultiStream = decodeMultiStream;
+    var Decoder_ts_1 = require_Decoder();
+    var stream_ts_1 = require_stream();
+    async function decodeAsync(streamLike, options) {
+      const stream = (0, stream_ts_1.ensureAsyncIterable)(streamLike);
+      const decoder = new Decoder_ts_1.Decoder(options);
+      return decoder.decodeAsync(stream);
+    }
+    function decodeArrayStream(streamLike, options) {
+      const stream = (0, stream_ts_1.ensureAsyncIterable)(streamLike);
+      const decoder = new Decoder_ts_1.Decoder(options);
+      return decoder.decodeArrayStream(stream);
+    }
+    function decodeMultiStream(streamLike, options) {
+      const stream = (0, stream_ts_1.ensureAsyncIterable)(streamLike);
+      const decoder = new Decoder_ts_1.Decoder(options);
+      return decoder.decodeStream(stream);
+    }
+  }
+});
+
+// ../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/index.cjs
+var require_dist = __commonJS({
+  "../node_modules/.pnpm/@msgpack+msgpack@3.1.3/node_modules/@msgpack/msgpack/dist.cjs/index.cjs"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.decodeTimestampExtension = exports.encodeTimestampExtension = exports.decodeTimestampToTimeSpec = exports.encodeTimeSpecToTimestamp = exports.encodeDateToTimeSpec = exports.EXT_TIMESTAMP = exports.ExtData = exports.ExtensionCodec = exports.Encoder = exports.DecodeError = exports.Decoder = exports.decodeMultiStream = exports.decodeArrayStream = exports.decodeAsync = exports.decodeMulti = exports.decode = exports.encode = void 0;
+    var encode_ts_1 = require_encode();
+    Object.defineProperty(exports, "encode", { enumerable: true, get: function() {
+      return encode_ts_1.encode;
+    } });
+    var decode_ts_1 = require_decode();
+    Object.defineProperty(exports, "decode", { enumerable: true, get: function() {
+      return decode_ts_1.decode;
+    } });
+    Object.defineProperty(exports, "decodeMulti", { enumerable: true, get: function() {
+      return decode_ts_1.decodeMulti;
+    } });
+    var decodeAsync_ts_1 = require_decodeAsync();
+    Object.defineProperty(exports, "decodeAsync", { enumerable: true, get: function() {
+      return decodeAsync_ts_1.decodeAsync;
+    } });
+    Object.defineProperty(exports, "decodeArrayStream", { enumerable: true, get: function() {
+      return decodeAsync_ts_1.decodeArrayStream;
+    } });
+    Object.defineProperty(exports, "decodeMultiStream", { enumerable: true, get: function() {
+      return decodeAsync_ts_1.decodeMultiStream;
+    } });
+    var Decoder_ts_1 = require_Decoder();
+    Object.defineProperty(exports, "Decoder", { enumerable: true, get: function() {
+      return Decoder_ts_1.Decoder;
+    } });
+    var DecodeError_ts_1 = require_DecodeError();
+    Object.defineProperty(exports, "DecodeError", { enumerable: true, get: function() {
+      return DecodeError_ts_1.DecodeError;
+    } });
+    var Encoder_ts_1 = require_Encoder();
+    Object.defineProperty(exports, "Encoder", { enumerable: true, get: function() {
+      return Encoder_ts_1.Encoder;
+    } });
+    var ExtensionCodec_ts_1 = require_ExtensionCodec();
+    Object.defineProperty(exports, "ExtensionCodec", { enumerable: true, get: function() {
+      return ExtensionCodec_ts_1.ExtensionCodec;
+    } });
+    var ExtData_ts_1 = require_ExtData();
+    Object.defineProperty(exports, "ExtData", { enumerable: true, get: function() {
+      return ExtData_ts_1.ExtData;
+    } });
+    var timestamp_ts_1 = require_timestamp();
+    Object.defineProperty(exports, "EXT_TIMESTAMP", { enumerable: true, get: function() {
+      return timestamp_ts_1.EXT_TIMESTAMP;
+    } });
+    Object.defineProperty(exports, "encodeDateToTimeSpec", { enumerable: true, get: function() {
+      return timestamp_ts_1.encodeDateToTimeSpec;
+    } });
+    Object.defineProperty(exports, "encodeTimeSpecToTimestamp", { enumerable: true, get: function() {
+      return timestamp_ts_1.encodeTimeSpecToTimestamp;
+    } });
+    Object.defineProperty(exports, "decodeTimestampToTimeSpec", { enumerable: true, get: function() {
+      return timestamp_ts_1.decodeTimestampToTimeSpec;
+    } });
+    Object.defineProperty(exports, "encodeTimestampExtension", { enumerable: true, get: function() {
+      return timestamp_ts_1.encodeTimestampExtension;
+    } });
+    Object.defineProperty(exports, "decodeTimestampExtension", { enumerable: true, get: function() {
+      return timestamp_ts_1.decodeTimestampExtension;
+    } });
+  }
+});
+
+// src/executor.ts
+import { createRequire } from "node:module";
+import { resolve as resolve2, dirname } from "node:path";
+
+// ../sdk/dist/index.mjs
+import { randomUUID } from "node:crypto";
+var CONTRACT_VERSION = "0.1.0";
+var TerminalEventError = class extends Error {
+  constructor() {
+    super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");
+    this.name = "TerminalEventError";
+  }
+};
+var SinkFailedError = class extends Error {
+  constructor(cause) {
+    super("Cannot emit: sink has previously failed");
+    this.name = "SinkFailedError";
+    this.cause = cause;
+  }
+};
+function createEmitAPI(run, sink) {
+  let seq = 0;
+  let terminalEmitted = false;
+  let sinkFailed = null;
+  let chain = Promise.resolve();
+  function serialize(fn) {
+    const result = chain.then(async () => {
+      if (sinkFailed !== null) throw new SinkFailedError(sinkFailed);
+      try {
+        return await fn();
+      } catch (err) {
+        sinkFailed = err;
+        throw err;
+      }
+    });
+    chain = result.then(() => {
+    }, () => {
+    });
+    return result;
+  }
+  function createEnvelope(type, payload) {
+    return {
+      contract_version: CONTRACT_VERSION,
+      event_id: randomUUID(),
+      run_id: run.run_id,
+      type,
+      ts: (/* @__PURE__ */ new Date()).toISOString(),
+      payload,
+      attempt: run.attempt,
+      ...run.job_id !== void 0 && { job_id: run.job_id },
+      ...run.parent_run_id !== void 0 && { parent_run_id: run.parent_run_id }
+    };
+  }
+  async function writeEnvelope(envelope) {
+    seq += 1;
+    const complete = {
+      ...envelope,
+      seq
+    };
+    await sink.writeEvent(complete);
+  }
+  function assertNotTerminal() {
+    if (terminalEmitted) throw new TerminalEventError();
+  }
+  const emit = {
+    item(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("item", {
+          item_type: options.item_type,
+          data: options.data
+        }));
+      });
+    },
+    artifact(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        const artifact_id = randomUUID();
+        const size_bytes = options.data.byteLength;
+        await sink.writeArtifactData(artifact_id, options.data);
+        await writeEnvelope(createEnvelope("artifact", {
+          artifact_id,
+          name: options.name,
+          content_type: options.content_type,
+          size_bytes
+        }));
+        return artifact_id;
+      });
+    },
+    checkpoint(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("checkpoint", {
+          checkpoint_id: options.checkpoint_id,
+          ...options.note !== void 0 && { note: options.note }
+        }));
+      });
+    },
+    enqueue(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("enqueue", {
+          target: options.target,
+          params: options.params
+        }));
+      });
+    },
+    rotateProxy(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("rotate_proxy", { ...options?.reason !== void 0 && { reason: options.reason } }));
+      });
+    },
+    log(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("log", {
+          level: options.level,
+          message: options.message,
+          ...options.fields !== void 0 && { fields: options.fields }
+        }));
+      });
+    },
+    async debug(message, fields) {
+      await emit.log({
+        level: "debug",
+        message,
+        fields
+      });
+    },
+    async info(message, fields) {
+      await emit.log({
+        level: "info",
+        message,
+        fields
+      });
+    },
+    async warn(message, fields) {
+      await emit.log({
+        level: "warn",
+        message,
+        fields
+      });
+    },
+    async error(message, fields) {
+      await emit.log({
+        level: "error",
+        message,
+        fields
+      });
+    },
+    runError(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("run_error", {
+          error_type: options.error_type,
+          message: options.message,
+          ...options.stack !== void 0 && { stack: options.stack }
+        }));
+        terminalEmitted = true;
+      });
+    },
+    runComplete(options) {
+      return serialize(async () => {
+        assertNotTerminal();
+        await writeEnvelope(createEnvelope("run_complete", { ...options?.summary !== void 0 && { summary: options.summary } }));
+        terminalEmitted = true;
+      });
+    }
+  };
+  return emit;
+}
+function createContext(options) {
+  const emit = createEmitAPI(options.run, options.sink);
+  const ctx = {
+    job: options.job,
+    run: Object.freeze(options.run),
+    page: options.page,
+    browser: options.browser,
+    browserContext: options.browserContext,
+    emit
+  };
+  return Object.freeze(ctx);
+}
+
+// src/ipc/observing-sink.ts
+var SinkAlreadyFailedError = class extends Error {
+  constructor(originalCause) {
+    const causeMsg = originalCause instanceof Error ? originalCause.message : String(originalCause);
+    super(`Sink has already failed: ${causeMsg}`);
+    this.name = "SinkAlreadyFailedError";
+    this.cause = originalCause;
+  }
+};
+function isTerminalType(type) {
+  return type === "run_complete" || type === "run_error";
+}
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+var ObservingSink = class {
+  constructor(inner) {
+    this.inner = inner;
+  }
+  terminalState = null;
+  sinkFailure = null;
+  /**
+   * Write an event envelope, tracking the first terminal event on success.
+   * @throws SinkAlreadyFailedError if the sink has previously failed
+   */
+  async writeEvent(envelope) {
+    if (this.sinkFailure !== null) {
+      throw new SinkAlreadyFailedError(this.sinkFailure);
+    }
+    try {
+      await this.inner.writeEvent(envelope);
+      if (this.terminalState === null && isTerminalType(envelope.type)) {
+        this.terminalState = this.extractTerminalState(envelope.type, envelope.payload);
+      }
+    } catch (err) {
+      if (this.sinkFailure === null) {
+        this.sinkFailure = err;
+      }
+      throw err;
+    }
+  }
+  /**
+   * Write artifact data, tracking failures.
+   * @throws SinkAlreadyFailedError if the sink has previously failed
+   */
+  async writeArtifactData(artifactId, data) {
+    if (this.sinkFailure !== null) {
+      throw new SinkAlreadyFailedError(this.sinkFailure);
+    }
+    try {
+      await this.inner.writeArtifactData(artifactId, data);
+    } catch (err) {
+      if (this.sinkFailure === null) {
+        this.sinkFailure = err;
+      }
+      throw err;
+    }
+  }
+  /**
+   * Extract terminal state from type and payload.
+   * Type alone is authoritative; payload fields are best-effort.
+   */
+  extractTerminalState(type, payload) {
+    if (type === "run_error") {
+      let errorType;
+      let message;
+      if (isPlainObject(payload)) {
+        if ("error_type" in payload && typeof payload.error_type === "string") {
+          errorType = payload.error_type;
+        }
+        if ("message" in payload && typeof payload.message === "string") {
+          message = payload.message;
+        }
+      }
+      return { type: "run_error", errorType, message };
+    }
+    let summary;
+    if (isPlainObject(payload) && "summary" in payload && isPlainObject(payload.summary)) {
+      summary = payload.summary;
+    }
+    return { type: "run_complete", summary };
+  }
+  // SinkState implementation
+  getTerminalState() {
+    return this.terminalState;
+  }
+  isSinkFailed() {
+    return this.sinkFailure !== null;
+  }
+  getSinkFailure() {
+    return this.sinkFailure;
+  }
+};
+
+// src/ipc/frame.ts
+var import_msgpack = __toESM(require_dist(), 1);
+var MAX_FRAME_SIZE = 16 * 1024 * 1024;
+var MAX_PAYLOAD_SIZE = MAX_FRAME_SIZE - 4;
+var MAX_CHUNK_SIZE = 8 * 1024 * 1024;
+var LENGTH_PREFIX_SIZE = 4;
+var FrameSizeError = class extends Error {
+  constructor(payloadSize, maxPayloadSize) {
+    super(`Payload size ${payloadSize} exceeds maximum ${maxPayloadSize}`);
+    this.payloadSize = payloadSize;
+    this.maxPayloadSize = maxPayloadSize;
+    this.name = "FrameSizeError";
+  }
+};
+function encodeFrame(payload) {
+  if (payload.length > MAX_PAYLOAD_SIZE) {
+    throw new FrameSizeError(payload.length, MAX_PAYLOAD_SIZE);
+  }
+  const frame = Buffer.allocUnsafe(LENGTH_PREFIX_SIZE + payload.length);
+  frame.writeUInt32BE(payload.length, 0);
+  frame.set(payload, LENGTH_PREFIX_SIZE);
+  return frame;
+}
+function encodeEventFrame(envelope) {
+  const payload = (0, import_msgpack.encode)(envelope);
+  return encodeFrame(payload);
+}
+var ChunkValidationError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ChunkValidationError";
+  }
+};
+function encodeArtifactChunkFrame(artifactId, seq, isLast, data) {
+  if (seq < 1) {
+    throw new ChunkValidationError(`seq must be >= 1, got ${seq}`);
+  }
+  if (data.length > MAX_CHUNK_SIZE) {
+    throw new ChunkValidationError(
+      `data size ${data.length} exceeds MAX_CHUNK_SIZE ${MAX_CHUNK_SIZE}`
+    );
+  }
+  const frame = {
+    type: "artifact_chunk",
+    artifact_id: artifactId,
+    seq,
+    is_last: isLast,
+    data
+  };
+  const payload = (0, import_msgpack.encode)(frame);
+  return encodeFrame(payload);
+}
+function calculateChunks(totalSize) {
+  const chunks = [];
+  if (totalSize === 0) {
+    chunks.push({ seq: 1, isLast: true, offset: 0, length: 0 });
+    return chunks;
+  }
+  let offset = 0;
+  let seq = 1;
+  while (offset < totalSize) {
+    const remaining = totalSize - offset;
+    const length = Math.min(remaining, MAX_CHUNK_SIZE);
+    const isLast = offset + length >= totalSize;
+    chunks.push({ seq, isLast, offset, length });
+    offset += length;
+    seq++;
+  }
+  return chunks;
+}
+function* encodeArtifactChunks(artifactId, data) {
+  const chunks = calculateChunks(data.length);
+  for (const chunk of chunks) {
+    const chunkData = data.subarray(chunk.offset, chunk.offset + chunk.length);
+    yield encodeArtifactChunkFrame(artifactId, chunk.seq, chunk.isLast, chunkData);
+  }
+}
+function encodeRunResultFrame(outcome, proxyUsed) {
+  const frame = {
+    type: "run_result",
+    outcome,
+    ...proxyUsed && { proxy_used: proxyUsed }
+  };
+  const payload = (0, import_msgpack.encode)(frame);
+  return encodeFrame(payload);
+}
+
+// src/ipc/sink.ts
+var StreamClosedError = class extends Error {
+  constructor(reason) {
+    super(`Output stream unavailable: ${reason}`);
+    this.name = "StreamClosedError";
+  }
+};
+function writeWithBackpressure(stream, data) {
+  return new Promise((resolve3, reject) => {
+    if (stream.destroyed) {
+      reject(new StreamClosedError("destroyed"));
+      return;
+    }
+    if (stream.writableEnded || stream.writableFinished) {
+      reject(new StreamClosedError("ended"));
+      return;
+    }
+    let settled = false;
+    const settle = (fn) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const onError = (err) => settle(() => reject(err));
+    const onClose = () => settle(() => reject(new StreamClosedError("close")));
+    const onFinish = () => settle(() => reject(new StreamClosedError("finish")));
+    const onDrain = () => settle(() => resolve3());
+    const cleanup = () => {
+      stream.off("error", onError);
+      stream.off("close", onClose);
+      stream.off("finish", onFinish);
+      stream.off("drain", onDrain);
+    };
+    stream.on("error", onError);
+    stream.on("close", onClose);
+    stream.on("finish", onFinish);
+    const canContinue = stream.write(data);
+    if (canContinue) {
+      setImmediate(() => settle(() => resolve3()));
+    } else {
+      stream.on("drain", onDrain);
+    }
+  });
+}
+var StdioSink = class {
+  constructor(output) {
+    this.output = output;
+  }
+  /**
+   * Write an event envelope as a framed message.
+   * Blocks on backpressure per CONTRACT_IPC.md.
+   */
+  async writeEvent(envelope) {
+    const frame = encodeEventFrame(envelope);
+    await writeWithBackpressure(this.output, frame);
+  }
+  /**
+   * Write artifact binary data as chunked frames.
+   * Per CONTRACT_IPC.md, bytes are written BEFORE the artifact event.
+   * Blocks on backpressure per CONTRACT_IPC.md.
+   */
+  async writeArtifactData(artifactId, data) {
+    for (const frame of encodeArtifactChunks(artifactId, data)) {
+      await writeWithBackpressure(this.output, frame);
+    }
+  }
+  /**
+   * Write a run result control frame.
+   * Per CONTRACT_IPC.md, this is a control frame emitted once after terminal event.
+   * It does NOT affect seq ordering.
+   *
+   * @param outcome - The run outcome
+   * @param proxyUsed - Optional redacted proxy endpoint (no password)
+   */
+  async writeRunResult(outcome, proxyUsed) {
+    const frame = encodeRunResultFrame(outcome, proxyUsed);
+    await writeWithBackpressure(this.output, frame);
+  }
+};
+
+// src/loader.ts
+import { isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+var ScriptLoadError = class extends Error {
+  constructor(scriptPath, reason) {
+    super(`Failed to load script "${scriptPath}": ${reason}`);
+    this.scriptPath = scriptPath;
+    this.reason = reason;
+    this.name = "ScriptLoadError";
+  }
+};
+function isFunction(value) {
+  return typeof value === "function";
+}
+function isOptionalFunction(value) {
+  return value === void 0 || isFunction(value);
+}
+async function loadScript(scriptPath) {
+  const absolutePath = isAbsolute(scriptPath) ? scriptPath : resolve(process.cwd(), scriptPath);
+  const fileUrl = pathToFileURL(absolutePath).href;
+  let module;
+  try {
+    module = await import(fileUrl);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ScriptLoadError(scriptPath, `import failed: ${message}`);
+  }
+  if (module === null || typeof module !== "object") {
+    throw new ScriptLoadError(scriptPath, "module is not an object");
+  }
+  const mod = module;
+  if (!("default" in mod)) {
+    throw new ScriptLoadError(scriptPath, "missing default export");
+  }
+  if (!isFunction(mod.default)) {
+    throw new ScriptLoadError(scriptPath, "default export is not a function");
+  }
+  if (!isOptionalFunction(mod.beforeRun)) {
+    throw new ScriptLoadError(scriptPath, "beforeRun hook is not a function");
+  }
+  if (!isOptionalFunction(mod.afterRun)) {
+    throw new ScriptLoadError(scriptPath, "afterRun hook is not a function");
+  }
+  if (!isOptionalFunction(mod.onError)) {
+    throw new ScriptLoadError(scriptPath, "onError hook is not a function");
+  }
+  if (!isOptionalFunction(mod.cleanup)) {
+    throw new ScriptLoadError(scriptPath, "cleanup hook is not a function");
+  }
+  const validatedModule = mod;
+  return {
+    script: validatedModule.default,
+    hooks: {
+      beforeRun: validatedModule.beforeRun,
+      afterRun: validatedModule.afterRun,
+      onError: validatedModule.onError,
+      cleanup: validatedModule.cleanup
+    },
+    module: validatedModule
+  };
+}
+
+// src/executor.ts
+var puppeteerModule = null;
+async function getPuppeteer(scriptPath) {
+  if (puppeteerModule) {
+    return puppeteerModule;
+  }
+  const absoluteScriptPath = resolve2(scriptPath);
+  const scriptDir = dirname(absoluteScriptPath);
+  try {
+    const require2 = createRequire(absoluteScriptPath);
+    const puppeteerPath = require2.resolve("puppeteer");
+    const mod = await import(puppeteerPath);
+    const pptr = mod.default;
+    puppeteerModule = pptr;
+    return pptr;
+  } catch {
+  }
+  try {
+    const mod = await import("puppeteer");
+    const pptr = mod.default;
+    puppeteerModule = pptr;
+    return pptr;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to load puppeteer: ${message}
+Puppeteer is a peer dependency of quarry-executor. Install it in your project (${scriptDir}): npm install puppeteer`
+    );
+  }
+}
+function parseRunMeta(input) {
+  if (input === null || typeof input !== "object") {
+    throw new Error("run metadata must be an object");
+  }
+  const obj = input;
+  if (typeof obj.run_id !== "string" || obj.run_id === "") {
+    throw new Error("run_id must be a non-empty string");
+  }
+  if (typeof obj.attempt !== "number" || !Number.isInteger(obj.attempt) || obj.attempt < 1) {
+    throw new Error("attempt must be a positive integer");
+  }
+  const hasParentRunId = typeof obj.parent_run_id === "string" && obj.parent_run_id !== "";
+  if (obj.attempt === 1 && hasParentRunId) {
+    throw new Error("initial run (attempt=1) must not have parent_run_id");
+  }
+  if (obj.attempt > 1 && !hasParentRunId) {
+    throw new Error(`retry run (attempt=${obj.attempt}) must have parent_run_id`);
+  }
+  const run = {
+    run_id: obj.run_id,
+    attempt: obj.attempt,
+    ...typeof obj.job_id === "string" && obj.job_id !== "" && { job_id: obj.job_id },
+    ...hasParentRunId && { parent_run_id: obj.parent_run_id }
+  };
+  return run;
+}
+function buildPuppeteerLaunchOptions(baseOptions, proxy) {
+  if (!proxy) {
+    return baseOptions ?? {};
+  }
+  const proxyUrl = `${proxy.protocol}://${proxy.host}:${proxy.port}`;
+  const existingArgs = baseOptions?.args ?? [];
+  const proxyArgs = [`--proxy-server=${proxyUrl}`];
+  return {
+    ...baseOptions,
+    args: [...existingArgs, ...proxyArgs]
+  };
+}
+function isSinkFailure(err) {
+  if (err instanceof TerminalEventError) {
+    return false;
+  }
+  if (err instanceof SinkAlreadyFailedError) {
+    return true;
+  }
+  return true;
+}
+function toRunResultOutcome(outcome) {
+  switch (outcome.status) {
+    case "completed":
+      return {
+        status: "completed",
+        message: outcome.summary ? "run completed with summary" : "run completed"
+      };
+    case "error":
+      return {
+        status: "error",
+        message: outcome.message,
+        error_type: outcome.errorType,
+        stack: outcome.stack
+      };
+    case "crash":
+      return {
+        status: "crash",
+        message: outcome.message
+      };
+  }
+}
+function redactProxy(proxy) {
+  return {
+    protocol: proxy.protocol,
+    host: proxy.host,
+    port: proxy.port,
+    ...proxy.username && { username: proxy.username }
+  };
+}
+async function execute(config) {
+  const output = config.output ?? process.stdout;
+  const stdioSink = new StdioSink(output);
+  const sink = new ObservingSink(stdioSink);
+  let browser = null;
+  let browserContext = null;
+  let page = null;
+  let script = null;
+  let ctx = null;
+  let scriptThrew = false;
+  let scriptError = null;
+  function determineOutcome(sinkState) {
+    if (sinkState.isSinkFailed()) {
+      const failure = sinkState.getSinkFailure();
+      const message = failure instanceof Error ? failure.message : String(failure);
+      return {
+        outcome: { status: "crash", message },
+        terminalEmitted: sinkState.getTerminalState() !== null
+      };
+    }
+    const terminalState = sinkState.getTerminalState();
+    if (terminalState !== null) {
+      if (terminalState.type === "run_error") {
+        return {
+          outcome: {
+            status: "error",
+            errorType: terminalState.errorType ?? "unknown",
+            message: terminalState.message ?? "Unknown error"
+          },
+          terminalEmitted: true
+        };
+      }
+      return {
+        outcome: { status: "completed", summary: terminalState.summary },
+        terminalEmitted: true
+      };
+    }
+    if (scriptThrew && scriptError) {
+      return {
+        outcome: {
+          status: "error",
+          errorType: "script_error",
+          message: scriptError.message,
+          stack: scriptError.stack
+        },
+        terminalEmitted: false
+      };
+    }
+    return {
+      outcome: { status: "completed" },
+      terminalEmitted: false
+    };
+  }
+  try {
+    try {
+      script = await loadScript(config.scriptPath);
+    } catch (err) {
+      if (err instanceof ScriptLoadError) {
+        return {
+          outcome: { status: "crash", message: err.message },
+          terminalEmitted: false
+        };
+      }
+      throw err;
+    }
+    const puppeteer = await getPuppeteer(config.scriptPath);
+    const launchOptions = buildPuppeteerLaunchOptions(config.puppeteerOptions, config.proxy);
+    browser = await puppeteer.launch(launchOptions);
+    browserContext = await browser.createBrowserContext();
+    page = await browserContext.newPage();
+    if (config.proxy?.username && config.proxy?.password) {
+      await page.authenticate({
+        username: config.proxy.username,
+        password: config.proxy.password
+      });
+    }
+    ctx = createContext({
+      job: config.job,
+      run: config.run,
+      page,
+      browser,
+      browserContext,
+      sink
+    });
+    try {
+      if (script.hooks.beforeRun) {
+        await script.hooks.beforeRun(ctx);
+      }
+      await script.script(ctx);
+      if (script.hooks.afterRun) {
+        await script.hooks.afterRun(ctx);
+      }
+    } catch (err) {
+      scriptThrew = true;
+      scriptError = {
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : void 0
+      };
+      if (script.hooks.onError && sink.getTerminalState() === null) {
+        try {
+          await script.hooks.onError(err, ctx);
+        } catch {
+        }
+      }
+    }
+    if (!sink.isSinkFailed() && sink.getTerminalState() === null) {
+      try {
+        if (scriptThrew && scriptError) {
+          await ctx.emit.runError({
+            error_type: "script_error",
+            message: scriptError.message,
+            stack: scriptError.stack
+          });
+        } else {
+          await ctx.emit.runComplete();
+        }
+      } catch (err) {
+        if (isSinkFailure(err)) {
+        }
+      }
+    }
+    if (script.hooks.cleanup && ctx) {
+      try {
+        await script.hooks.cleanup(ctx);
+      } catch {
+      }
+    }
+    const result = determineOutcome(sink);
+    try {
+      const runResultOutcome = toRunResultOutcome(result.outcome);
+      const proxyUsed = config.proxy ? redactProxy(config.proxy) : void 0;
+      await stdioSink.writeRunResult(runResultOutcome, proxyUsed);
+    } catch {
+    }
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const crashOutcome = { status: "crash", message };
+    try {
+      const runResultOutcome = toRunResultOutcome(crashOutcome);
+      const proxyUsed = config.proxy ? redactProxy(config.proxy) : void 0;
+      await stdioSink.writeRunResult(runResultOutcome, proxyUsed);
+    } catch {
+    }
+    return {
+      outcome: crashOutcome,
+      terminalEmitted: false
+    };
+  } finally {
+    if (page) {
+      try {
+        await page.close();
+      } catch {
+      }
+    }
+    if (browserContext) {
+      try {
+        await browserContext.close();
+      } catch {
+      }
+    }
+    if (browser) {
+      try {
+        await browser.close();
+      } catch {
+      }
+    }
+  }
+}
+
+// src/bin/executor.ts
+function parseProxy(input) {
+  if (!("proxy" in input) || input.proxy === null || input.proxy === void 0) {
+    return void 0;
+  }
+  const proxy = input.proxy;
+  if (typeof proxy.protocol !== "string") {
+    throw new Error("proxy.protocol must be a string");
+  }
+  if (typeof proxy.host !== "string" || proxy.host === "") {
+    throw new Error("proxy.host must be a non-empty string");
+  }
+  if (typeof proxy.port !== "number" || !Number.isInteger(proxy.port) || proxy.port < 1 || proxy.port > 65535) {
+    throw new Error("proxy.port must be an integer between 1 and 65535");
+  }
+  const validProtocols = ["http", "https", "socks5"];
+  if (!validProtocols.includes(proxy.protocol)) {
+    throw new Error(`proxy.protocol must be one of: ${validProtocols.join(", ")}`);
+  }
+  const hasUsername = typeof proxy.username === "string" && proxy.username !== "";
+  const hasPassword = typeof proxy.password === "string" && proxy.password !== "";
+  if (hasUsername !== hasPassword) {
+    throw new Error("proxy.username and proxy.password must be provided together");
+  }
+  return {
+    protocol: proxy.protocol,
+    host: proxy.host,
+    port: proxy.port,
+    ...hasUsername && { username: proxy.username },
+    ...hasPassword && { password: proxy.password }
+  };
+}
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    process.stderr.write("Usage: quarry-executor <script-path>\n");
+    process.stderr.write("Run metadata is read from stdin as JSON.\n");
+    process.exit(3);
+  }
+  const scriptPath = args[0];
+  let input;
+  try {
+    const stdinData = await readStdin();
+    if (stdinData.trim() === "") {
+      process.stderr.write("Error: stdin is empty, expected JSON input\n");
+      process.exit(3);
+    }
+    input = JSON.parse(stdinData);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error parsing stdin JSON: ${message}
+`);
+    process.exit(3);
+  }
+  if (input === null || typeof input !== "object") {
+    process.stderr.write("Error: stdin must be a JSON object\n");
+    process.exit(3);
+  }
+  const inputObj = input;
+  let run;
+  try {
+    run = parseRunMeta(inputObj);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error parsing run metadata: ${message}
+`);
+    process.exit(3);
+  }
+  if (!("job" in inputObj)) {
+    process.stderr.write('Error: missing "job" field in input\n');
+    process.exit(3);
+  }
+  const job = inputObj.job;
+  let proxy;
+  try {
+    proxy = parseProxy(inputObj);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error parsing proxy: ${message}
+`);
+    process.exit(3);
+  }
+  const result = await execute({
+    scriptPath,
+    job,
+    run,
+    proxy,
+    output: process.stdout,
+    puppeteerOptions: {
+      // Headless by default for executor mode
+      headless: true,
+      // Disable sandbox in containerized environments
+      args: process.env.QUARRY_NO_SANDBOX === "1" ? ["--no-sandbox", "--disable-setuid-sandbox"] : []
+    }
+  });
+  switch (result.outcome.status) {
+    case "completed":
+      process.exit(0);
+      break;
+    case "error":
+      process.exit(1);
+      break;
+    case "crash":
+      process.stderr.write(`Executor crash: ${result.outcome.message}
+`);
+      process.exit(2);
+      break;
+    default: {
+      const _exhaustive = result.outcome;
+      process.exit(2);
+    }
+  }
+}
+main().catch((err) => {
+  process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}
+`);
+  process.exit(2);
+});

--- a/quarry/executor/embed.go
+++ b/quarry/executor/embed.go
@@ -1,0 +1,105 @@
+// Package executor provides embedded executor management.
+//
+// The executor bundle is embedded at build time and extracted to a
+// temporary directory on first use. This allows the quarry binary to
+// be self-contained without requiring a separate executor installation.
+package executor
+
+import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/justapithecus/quarry/types"
+)
+
+//go:embed bundle/executor.mjs
+var embeddedExecutor []byte
+
+// extractOnce ensures extraction happens only once per process.
+var extractOnce sync.Once
+var extractedPath string
+var extractErr error
+
+// EmbeddedVersion returns the version of the embedded executor.
+// This should match types.Version for lockstep validation.
+func EmbeddedVersion() string {
+	return types.Version
+}
+
+// EmbeddedSize returns the size of the embedded executor in bytes.
+func EmbeddedSize() int {
+	return len(embeddedExecutor)
+}
+
+// EmbeddedChecksum returns the SHA256 checksum of the embedded executor.
+func EmbeddedChecksum() string {
+	hash := sha256.Sum256(embeddedExecutor)
+	return hex.EncodeToString(hash[:])
+}
+
+// IsEmbedded returns true if an executor is embedded in this binary.
+func IsEmbedded() bool {
+	return len(embeddedExecutor) > 0
+}
+
+// ExtractedPath returns the path to the extracted executor.
+// Extracts on first call; subsequent calls return cached path.
+// Returns error if extraction fails.
+func ExtractedPath() (string, error) {
+	extractOnce.Do(func() {
+		extractedPath, extractErr = extractExecutor()
+	})
+	return extractedPath, extractErr
+}
+
+// extractExecutor extracts the embedded executor to a temp directory.
+func extractExecutor() (string, error) {
+	if !IsEmbedded() {
+		return "", fmt.Errorf("no embedded executor available")
+	}
+
+	// Create quarry-specific temp directory
+	// Use a hash-based name to allow multiple versions to coexist
+	checksum := EmbeddedChecksum()[:16] // First 16 chars of SHA256
+	dirName := fmt.Sprintf("quarry-executor-%s-%s", types.Version, checksum)
+	tempDir := filepath.Join(os.TempDir(), dirName)
+
+	executorPath := filepath.Join(tempDir, "executor.mjs")
+
+	// Check if already extracted (idempotent)
+	if info, err := os.Stat(executorPath); err == nil && info.Size() == int64(len(embeddedExecutor)) {
+		return executorPath, nil
+	}
+
+	// Create directory
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	// Write executor file
+	if err := os.WriteFile(executorPath, embeddedExecutor, 0o755); err != nil {
+		return "", fmt.Errorf("failed to write executor: %w", err)
+	}
+
+	return executorPath, nil
+}
+
+// Cleanup removes the extracted executor directory.
+// Safe to call multiple times or if extraction never happened.
+func Cleanup() error {
+	if extractedPath == "" {
+		return nil
+	}
+
+	dir := filepath.Dir(extractedPath)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to cleanup executor: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Bundle the Node executor into the Go binary for self-contained distribution. Users no longer need to install the executor separately.

Changes:
- Add esbuild bundle script for executor + SDK + msgpack
- Implement Go embed with content-addressed temp extraction
- Convert puppeteer to lazy import resolved from script location
- Add executor:bundle task with proper ts:build dependency
- Update CLI to prioritize embedded executor, preserve --executor override

Binary size: ~28MB (includes ~87KB embedded bundle)