### PR TITLE
docs(lode): 📝 update release readiness and guides for typed errors

### DIFF
--- a/docs/RELEASE_READINESS_v0.1.0.md
+++ b/docs/RELEASE_READINESS_v0.1.0.md
@@ -135,24 +135,37 @@ All gates must be satisfied before tagging a release.
 | S3: bucket access denied tested | ✅ | TestLodeClient_S3AccessDenied |
 | S3: network timeout tested | ✅ | TestLodeClient_S3NetworkTimeout |
 | S3: throttling (429) tested | ✅ | TestLodeClient_S3Throttling |
-| Error messages include storage context | ✅ | TestLodeClient_ErrorContainsStorageContext |
+| Error messages include storage context | ✅ | TestLodeClient_StorageError_ContainsOperationAndPath |
 | Policy failure propagation verified | ✅ | TestLodeClient_ErrorPropagation_* |
 | No silent corruption paths | ✅ | TestLodeClient_NoSilentCorruption_* |
+| Typed error classification verified | ✅ | See Phase 10 (errors.Is/errors.As) |
 
 ### Phase 9 — Bundle Executor with Go Distribution
 
 | Item | Status | Notes |
 |------|--------|-------|
-| Executor embedded in quarry binary | ⬜ | Go embed for Node executor |
-| Executor extraction to temp dir | ⬜ | Extract on first run |
-| Executor version validation | ⬜ | Embedded matches expected |
-| Fallback to PATH executor | ⬜ | If embedded extraction fails |
-| Cross-platform extraction tested | ⬜ | Linux, macOS, Windows |
-| Extraction permissions correct | ⬜ | Executable bit set |
-| Temp dir cleanup on exit | ⬜ | No orphaned extractors |
-| `--executor` override still works | ⬜ | Explicit path takes precedence |
-| Build reproduces embedded content | ⬜ | Deterministic embed |
-| Binary size impact documented | ⬜ | Size delta tracked |
+| Executor embedded in quarry binary | ✅ | Go `//go:embed` for Node executor bundle |
+| Executor extraction to temp dir | ✅ | Content-addressed temp path with version+checksum |
+| Executor version validation | ✅ | Embedded version from `types.Version` |
+| Fallback to PATH executor | ✅ | Falls back if extraction fails |
+| Cross-platform extraction tested | ⚠️ | Linux validated; macOS/Windows TBD |
+| Extraction permissions correct | ✅ | Executable bit set (0755) |
+| Temp dir cleanup on exit | ⚠️ | Cleanup function exists; not auto-called |
+| `--executor` override still works | ✅ | Explicit path takes precedence |
+| Build reproduces embedded content | ✅ | esbuild bundle deterministic |
+| Binary size impact documented | ✅ | ~28MB total (~87KB bundle) |
+
+### Phase 10 — Typed Storage Errors & Test Robustness
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Sentinel errors defined | ✅ | ErrPermissionDenied, ErrNotFound, ErrDiskFull, ErrTimeout, ErrThrottled, ErrAuth, ErrAccessDenied, ErrNetwork |
+| StorageError wrapper with context | ✅ | Kind, Op, Path, underlying Err |
+| Backend boundary wrapping complete | ✅ | init, write events, write chunks all wrapped |
+| Tests migrated to errors.Is/errors.As | ✅ | No string matching in primary assertions |
+| Factory error paths have strict assertions | ✅ | No silent-success paths on init errors |
+| Error chain preserves original cause | ✅ | errors.Unwrap traverses to underlying error |
+| Platform-aware test skips documented | ✅ | Root-user skip for permission tests |
 
 ---
 
@@ -185,4 +198,4 @@ All gates must be satisfied before tagging a release.
 
 ---
 
-*Last updated: 2026-02-03*
+*Last updated: 2026-02-04*

--- a/docs/guides/lode.md
+++ b/docs/guides/lode.md
@@ -83,10 +83,13 @@ Validation is a downstream consumer responsibility.
 - If the path is not writable, the first write operation will fail.
 
 **Error Handling:**
+- Storage errors are classified and wrapped with context (operation, path).
 - Disk full errors (`ENOSPC`) are surfaced as policy failures.
 - Permission errors (`EACCES`) are surfaced as policy failures.
+- Not-found errors (missing directories) are surfaced at initialization or write time.
 - Quarry does **not** retry failed writes; errors propagate immediately.
 - The ingestion policy determines whether partial data is preserved on failure.
+- Error messages include actionable context (what operation failed, where).
 
 ### S3 Backend (Experimental)
 
@@ -97,6 +100,14 @@ Validation is a downstream consumer responsibility.
   3. IAM instance role (EC2/ECS/Lambda)
 - Credential validation happens on the **first write attempt**, not at startup.
 - If credentials are invalid or expired, the first write fails with an auth error.
+
+**Error Handling:**
+- Storage errors are classified and wrapped with context (operation, path).
+- Authentication failures (invalid/expired credentials) are surfaced as policy failures.
+- Access denied errors (valid credentials but insufficient permissions) are surfaced as policy failures.
+- Throttling errors (429/SlowDown) are surfaced immediately (no automatic retry).
+- Network timeouts are surfaced as policy failures.
+- Error messages include actionable context (what operation failed, where).
 
 **Consistency Caveats:**
 - S3 provides **strong read-after-write consistency** for PUTs (since Dec 2020).


### PR DESCRIPTION
Update docs to reflect Phase 10 typed error classification:

- Add Phase 10 section to RELEASE_READINESS_v0.1.0.md
- Update Phase 8/9 status with current state
- Update lode guide with error handling details for FS and S3
- Keep user-facing docs focused on behavior, not internal types