### PR TITLE
docs(cli): 📝 document job payload object-only contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **CLI**: `--job` description clarified as "inline JSON" to distinguish from `--job-json`
+- **CLI**: Job payload (`--job` and `--job-json`) now **requires** a top-level JSON object; arrays, primitives, and null are rejected with actionable error messages
 
 ---
 

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -168,12 +168,13 @@ quarry run [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--attempt <n>` | 1 | Attempt number |
-| `--job <json>` | `{}` | Job payload as inline JSON |
-| `--job-json <path>` | | Path to JSON file containing job payload |
+| `--job <json>` | `{}` | Job payload as inline JSON object |
+| `--job-json <path>` | | Path to JSON file containing job payload (must be object) |
 | `--category <name>` | `default` | Category for partitioning |
 | `--policy <strict\|buffered>` | `strict` | Ingestion policy |
 
 > **Note:** `--job` and `--job-json` are mutually exclusive. Using both is an error.
+> The payload **must** be a top-level JSON object. Arrays, primitives, and null are rejected.
 
 **Advanced flags:**
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -101,8 +101,8 @@ Optional flags:
 - `--attempt <n>` (default: 1)
 - `--job-id <id>`
 - `--parent-run-id <id>`
-- `--job <json>` (inline JSON payload)
-- `--job-json <path>` (load payload from file; mutually exclusive with `--job`)
+- `--job <json>` (inline JSON object; mutually exclusive with `--job-json`)
+- `--job-json <path>` (load JSON object from file; mutually exclusive with `--job`)
 - `--quiet`
 - `--policy strict|buffered`
 - `--flush-mode at_least_once|chunks_first|two_phase`
@@ -151,6 +151,31 @@ quarry run \
   --proxy-domain example.com \
   --job '{"source":"demo"}'
 ```
+
+#### Job Payload Contract
+
+The job payload (`--job` or `--job-json`) **must** be a top-level JSON object.
+
+**Valid:**
+```bash
+--job '{}'
+--job '{"url": "https://example.com"}'
+--job-json ./config.json  # file contains {"key": "value"}
+```
+
+**Invalid (rejected with error):**
+```bash
+--job '[]'           # array
+--job '"string"'     # primitive
+--job '123'          # primitive
+--job 'null'         # null
+```
+
+The flags are mutually exclusive:
+- Use `--job` for inline JSON objects
+- Use `--job-json` to load from a file
+- Using both is an error
+- If neither is specified, defaults to `{}`
 
 ### `inspect`
 


### PR DESCRIPTION
## Summary

- Documents that `--job` and `--job-json` require top-level JSON objects
- Adds validation rules to CLI documentation
- Updates CHANGELOG with contract clarification

## Test plan

- [x] Documentation accurately reflects implementation
- [x] CHANGELOG entry is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)