### PR TITLE
fix(build): 🐛 deduplicate ts:build in task graph

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,8 @@ tasks:
 
   build:
     desc: Build all packages (Go + TS)
-    deps: [go:build, ts:build]
+    # Note: ts:build is transitive via go:build → executor:bundle → ts:build
+    deps: [go:build]
 
   lint:
     desc: Lint all packages (Go + TS)
@@ -26,7 +27,8 @@ tasks:
 
   examples:
     desc: Run and validate all examples
-    deps: [go:build, ts:build]
+    # Note: ts:build is transitive via go:build → executor:bundle → ts:build
+    deps: [go:build]
     cmds:
       - pnpm exec tsx scripts/run-examples.ts
 


### PR DESCRIPTION
## Summary

- Remove redundant direct `ts:build` dependency from `build` and `examples` tasks
- `ts:build` is already transitive via `go:build` → `executor:bundle` → `ts:build`
- Fixes duplicate/interleaved TS build output and potential CI race conditions

## Before

```
build → ts:build (direct)
build → go:build → executor:bundle → ts:build (duplicate)
```

## After

```
build → go:build → executor:bundle → ts:build (single path)
```

## Test plan

- [x] `task build -n` shows ts:build only once
- [x] `task examples -n` shows ts:build only once

🤖 Generated with [Claude Code](https://claude.ai/code)