### PR TITLE
chore(release): 🔖 bump version to v0.2.0

### DIFF
--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.1.0"
+const Version = "0.2.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",


### PR DESCRIPTION
## Summary

Version bump for v0.2.0 release.

## Changes

- `quarry/types/version.go`: 0.1.0 → 0.2.0
- `sdk/package.json`: 0.1.0 → 0.2.0

## Pre-merge checklist

- [x] Version lockstep verified
- [x] All v0.2.0 gates passed
- [x] Known issue #56 documented in CHANGELOG and SUPPORT.md
- [x] v0.2.1 milestone created for follow-up

## Post-merge

1. Tag: `git tag v0.2.0 && git push origin v0.2.0`
2. Create GitHub release with notes
3. Begin v0.2.1 work on #56

🤖 Generated with [Claude Code](https://claude.ai/code)