### PR TITLE
chore(release): 🔖 v0.2.1 hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [0.2.1] - 2026-02-05
+
+### Fixed
+
+- **IPC**: Fixed race condition where fast-completing scripts intermittently reported `executor_crash` outcome despite successful completion ([#56](https://github.com/justapithecus/quarry/issues/56)). Root cause was Go's `exec.Cmd.Wait()` closing stdout pipe before ingestion completed reading all data.
+
+---
+
+## [0.2.0] - 2026-02-05
+
 ### Added
 
 - **CLI**: `--job-json <path>` flag to load job payload from file (alternative to inline `--job`)
@@ -16,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI**: CLI/config parity checker validates flag documentation against implementation
 - **CI**: Strict parity gate blocks merge on CLI documentation drift
 - **Examples**: Integration pattern examples (SNS, handler, filesystem polling, S3 polling)
-- **Docs**: v0.2.0 release readiness checklist
 
 ### Changed
 
@@ -27,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issues
 
-- **IPC race condition** ([#56](https://github.com/justapithecus/quarry/issues/56)): Fast-completing scripts may intermittently report `executor_crash` outcome despite successful completion. **Data is not affected** - all events are persisted correctly. Only the exit code and outcome classification are wrong. Workaround: verify `run_complete` event presence rather than relying solely on exit code. Fix targeted for v0.2.1.
+- **IPC race condition** ([#56](https://github.com/justapithecus/quarry/issues/56)): Fast-completing scripts may intermittently report `executor_crash` outcome despite successful completion. **Fixed in v0.2.1.**
 
 ---
 
@@ -95,4 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.2.1]: https://github.com/justapithecus/quarry/releases/tag/v0.2.1
+[0.2.0]: https://github.com/justapithecus/quarry/releases/tag/v0.2.0
 [0.1.0]: https://github.com/justapithecus/quarry/releases/tag/v0.1.0

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,27 +1,23 @@
-# Support Posture — Quarry v0.2.0
+# Support Posture — Quarry v0.2.1
 
-This document defines support expectations for Quarry v0.2.0.
+This document defines support expectations for Quarry v0.2.1.
 
 ---
 
 ## Maturity Level
 
-**v0.2.0 is an early release.** APIs and behaviors may change in subsequent
+**v0.2.1 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-### IPC Race Condition ([#56](https://github.com/justapithecus/quarry/issues/56))
+_No known issues in v0.2.1._
 
-**Symptom**: Fast-completing scripts may intermittently report `executor_crash` outcome with exit code 2, despite successful completion.
+### Fixed in v0.2.1
 
-**Impact**: Exit code and outcome classification may be wrong. **Data persistence is unaffected** - all emitted events are persisted correctly.
-
-**Workaround**: Verify the presence of `run_complete` event in storage rather than relying solely on exit code for success/failure detection.
-
-**Fix Target**: v0.2.1
+- **IPC Race Condition** ([#56](https://github.com/justapithecus/quarry/issues/56)): Fixed issue where fast-completing scripts intermittently reported `executor_crash` outcome. Upgrade to v0.2.1 to resolve.
 
 ---
 

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.2.0
+// Quarry Executor Bundle v0.2.1
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: pnpm run bundle
 
@@ -1744,7 +1744,7 @@ import { dirname, resolve as resolve2 } from "node:path";
 
 // ../sdk/dist/index.mjs
 import { randomUUID } from "node:crypto";
-var CONTRACT_VERSION = "0.2.0";
+var CONTRACT_VERSION = "0.2.1";
 var TerminalEventError = class extends Error {
   constructor() {
     super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/runtime/run.go
+++ b/quarry/runtime/run.go
@@ -168,8 +168,7 @@ func (r *RunOrchestrator) Execute(ctx context.Context) (*RunResult, error) {
 	// IMPORTANT: We must wait for ingestion before calling executor.Wait() because
 	// Go's exec.Cmd.Wait() closes StdoutPipe, which would cause ingestion reads to
 	// fail with "file already closed" even if data is still in the pipe buffer.
-	var ingErr error
-	ingErr = <-ingestionDone
+	ingErr := <-ingestionDone
 
 	// On ANY ingestion error (policy, stream, or canceled), kill executor immediately
 	// This prevents the executor from continuing to emit after we've decided to terminate

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.2.0"
+const Version = "0.2.1"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.2.0' as const
+export const CONTRACT_VERSION = '0.2.1' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/golden.test.ts
+++ b/sdk/test/emit/06-golden/golden.test.ts
@@ -15,8 +15,8 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createEmitAPI } from '../../../src/emit-impl'
-import { CONTRACT_VERSION } from '../../../src/types/events'
 import type { CheckpointId, EventEnvelope } from '../../../src/types/events'
+import { CONTRACT_VERSION } from '../../../src/types/events'
 import { createDeterministicRunMeta, FakeSink } from '../_harness'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.2.0",
+    "contract_version": "0.2.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Hotfix release v0.2.1 for IPC race condition fix.

### Changes

- **CHANGELOG.md**: Added missing v0.2.0 section, added v0.2.1 hotfix entry
- **Version bump**: Lockstep versions updated to 0.2.1
  - `quarry/types/version.go`
  - `sdk/package.json`
  - `sdk/src/types/events.ts` (CONTRACT_VERSION)
- **Golden tests**: Updated fixtures for v0.2.1
- **SUPPORT.md**: Updated to reflect fixed issue #56
- **Lint fixes**: staticcheck var declaration, biome import order

### Gates

- ✅ lint
- ✅ cli:parity
- ✅ test (Go + SDK + executor-node)
- ✅ build
- ✅ examples (5/5)

### Post-merge

After merge:
1. Tag `v0.2.1` on the merge commit
2. Create GitHub release with notes

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)