### PR TITLE
chore(go): 🎨 prefer errors.New over fmt.Errorf for static strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ If scope feels ambiguous or expanding, **pause and ask**.
 ## Go Rules
 
 - Prefer `any` over `interface{}`
+- Prefer `errors.New` over `fmt.Errorf` when no formatting verbs are needed
 
 ---
 

--- a/quarry/cli/cmd/run.go
+++ b/quarry/cli/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -707,7 +708,7 @@ func outcomeToExitCode(status types.OutcomeStatus) int {
 func selectProxy(config proxyChoice, runMeta *types.RunMeta) (*types.ProxyEndpoint, error) {
 	// Load proxy pools from config file
 	if config.configPath == "" {
-		return nil, fmt.Errorf("--proxy-config required when --proxy-pool is specified")
+		return nil, errors.New("--proxy-config required when --proxy-pool is specified")
 	}
 
 	pools, err := loadProxyPools(config.configPath)

--- a/quarry/cli/reader/stub.go
+++ b/quarry/cli/reader/stub.go
@@ -1,7 +1,7 @@
 package reader
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -224,7 +224,7 @@ func (r *StubReader) ListExecutors() []ListExecutorItem {
 // DebugResolveProxy returns stub proxy resolution.
 func (r *StubReader) DebugResolveProxy(pool string, commit bool) (*ResolveProxyResponse, error) {
 	if pool == "" {
-		return nil, fmt.Errorf("pool name required")
+		return nil, errors.New("pool name required")
 	}
 
 	return &ResolveProxyResponse{

--- a/quarry/executor/embed.go
+++ b/quarry/executor/embed.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,7 +61,7 @@ func ExtractedPath() (string, error) {
 // extractExecutor extracts the embedded executor to a temp directory.
 func extractExecutor() (string, error) {
 	if !IsEmbedded() {
-		return "", fmt.Errorf("no embedded executor available")
+		return "", errors.New("no embedded executor available")
 	}
 
 	// Create quarry-specific temp directory

--- a/quarry/lode/client.go
+++ b/quarry/lode/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -20,11 +21,11 @@ const checksumEnabled = false
 
 // ErrCommitWithoutChunks is returned when an artifact commit is attempted
 // without any chunks having been written for that artifact.
-var ErrCommitWithoutChunks = fmt.Errorf("artifact commit rejected: no chunks written for artifact")
+var ErrCommitWithoutChunks = errors.New("artifact commit rejected: no chunks written for artifact")
 
 // ErrMissingArtifactID is returned when an artifact commit event is missing
 // the required artifact_id field.
-var ErrMissingArtifactID = fmt.Errorf("artifact commit rejected: missing or empty artifact_id")
+var ErrMissingArtifactID = errors.New("artifact commit rejected: missing or empty artifact_id")
 
 // LodeClient is a real Lode-backed implementation of Client.
 // Uses Lode's HiveLayout with partition keys: source/category/day/run_id/event_type.

--- a/quarry/lode/client_s3.go
+++ b/quarry/lode/client_s3.go
@@ -2,6 +2,7 @@ package lode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -24,7 +25,7 @@ type S3Config struct {
 // Validate checks that required S3 configuration is present.
 func (c *S3Config) Validate() error {
 	if c.Bucket == "" {
-		return fmt.Errorf("S3 bucket is required")
+		return errors.New("S3 bucket is required")
 	}
 	return nil
 }

--- a/quarry/lode/metrics_query.go
+++ b/quarry/lode/metrics_query.go
@@ -2,6 +2,7 @@ package lode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/justapithecus/lode/lode"
@@ -10,7 +11,7 @@ import (
 )
 
 // ErrNoMetricsFound is returned when no metrics records exist in the dataset.
-var ErrNoMetricsFound = fmt.Errorf("no metrics records found")
+var ErrNoMetricsFound = errors.New("no metrics records found")
 
 // QueryLatestMetrics finds and reads the most recent metrics record from Lode.
 // Filters by runID and source if non-empty.
@@ -69,7 +70,7 @@ func QueryLatestMetrics(ctx context.Context, ds lode.Dataset, runID, source stri
 // Handles both int64 (direct writes) and float64 (JSON round-trips) for numeric fields.
 func ParseMetricsRecord(record map[string]any) (*reader.MetricsSnapshot, error) {
 	if record == nil {
-		return nil, fmt.Errorf("nil record")
+		return nil, errors.New("nil record")
 	}
 
 	snap := &reader.MetricsSnapshot{
@@ -114,19 +115,19 @@ func ParseMetricsRecord(record map[string]any) (*reader.MetricsSnapshot, error) 
 	// The write path always populates these; missing values indicate
 	// data corruption or a malformed record.
 	if snap.Ts == "" {
-		return nil, fmt.Errorf("metrics record missing required field: ts")
+		return nil, errors.New("metrics record missing required field: ts")
 	}
 	if snap.RunID == "" {
-		return nil, fmt.Errorf("metrics record missing required field: run_id")
+		return nil, errors.New("metrics record missing required field: run_id")
 	}
 	if snap.Policy == "" {
-		return nil, fmt.Errorf("metrics record missing required field: policy")
+		return nil, errors.New("metrics record missing required field: policy")
 	}
 	if snap.Executor == "" {
-		return nil, fmt.Errorf("metrics record missing required field: executor")
+		return nil, errors.New("metrics record missing required field: executor")
 	}
 	if snap.StorageBackend == "" {
-		return nil, fmt.Errorf("metrics record missing required field: storage_backend")
+		return nil, errors.New("metrics record missing required field: storage_backend")
 	}
 
 	return snap, nil

--- a/quarry/proxy/selector.go
+++ b/quarry/proxy/selector.go
@@ -3,6 +3,7 @@ package proxy
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -160,7 +161,7 @@ func (s *Selector) selectSticky(state *poolState, req SelectRequest, commit bool
 	// Derive sticky key per CONTRACT_PROXY.md precedence
 	stickyKey := s.deriveStickyKey(state, req)
 	if stickyKey == "" {
-		return 0, fmt.Errorf("sticky selection requires a sticky key")
+		return 0, errors.New("sticky selection requires a sticky key")
 	}
 
 	now := time.Now()

--- a/quarry/runtime/executor.go
+++ b/quarry/runtime/executor.go
@@ -131,7 +131,7 @@ func (m *ExecutorManager) Stderr() io.Reader {
 // Must be called after Start.
 func (m *ExecutorManager) Wait() (*ExecutorResult, error) {
 	if m.cmd == nil {
-		return nil, fmt.Errorf("executor not started")
+		return nil, errors.New("executor not started")
 	}
 
 	// Read stderr (non-blocking capture)

--- a/quarry/runtime/ingestion.go
+++ b/quarry/runtime/ingestion.go
@@ -312,7 +312,7 @@ func (e *IngestionEngine) handleArtifactCommit(envelope *types.EventEnvelope) er
 	// Extract artifact metadata from payload
 	artifactID, _ := envelope.Payload["artifact_id"].(string)
 	if artifactID == "" {
-		return fmt.Errorf("artifact event missing artifact_id")
+		return errors.New("artifact event missing artifact_id")
 	}
 
 	// size_bytes may come as various integer types from msgpack encoding

--- a/quarry/types/lineage.go
+++ b/quarry/types/lineage.go
@@ -4,7 +4,10 @@
 //nolint:revive // types is a common Go package naming convention
 package types
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // RunMeta contains run identity and lineage metadata per CONTRACT_RUN.md.
 type RunMeta struct {
@@ -24,7 +27,7 @@ type RunMeta struct {
 //   - attempt > 1 => parent_run_id must be present (retry run)
 func (r *RunMeta) Validate() error {
 	if r.RunID == "" {
-		return fmt.Errorf("run_id must be non-empty")
+		return errors.New("run_id must be non-empty")
 	}
 
 	if r.Attempt < 1 {
@@ -32,7 +35,7 @@ func (r *RunMeta) Validate() error {
 	}
 
 	if r.Attempt == 1 && r.ParentRunID != nil {
-		return fmt.Errorf("initial run (attempt=1) must not have parent_run_id")
+		return errors.New("initial run (attempt=1) must not have parent_run_id")
 	}
 
 	if r.Attempt > 1 && r.ParentRunID == nil {

--- a/quarry/types/proxy.go
+++ b/quarry/types/proxy.go
@@ -1,7 +1,10 @@
 // Package types defines core domain types for the Quarry runtime.
 package types
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ProxyProtocol is the allowed proxy protocol.
 // Note: socks5 is best-effort with Puppeteer.
@@ -68,7 +71,7 @@ func (p *ProxyEndpoint) Validate() error {
 	hasUsername := p.Username != nil && *p.Username != ""
 	hasPassword := p.Password != nil && *p.Password != ""
 	if hasUsername != hasPassword {
-		return fmt.Errorf("username and password must be provided together")
+		return errors.New("username and password must be provided together")
 	}
 
 	return nil
@@ -117,7 +120,7 @@ type ProxyPool struct {
 // Validate validates a proxy pool per CONTRACT_PROXY.md hard validation rules.
 func (p *ProxyPool) Validate() error {
 	if p.Name == "" {
-		return fmt.Errorf("pool name is required")
+		return errors.New("pool name is required")
 	}
 
 	switch p.Strategy {
@@ -128,7 +131,7 @@ func (p *ProxyPool) Validate() error {
 	}
 
 	if len(p.Endpoints) == 0 {
-		return fmt.Errorf("pool must have at least one endpoint")
+		return errors.New("pool must have at least one endpoint")
 	}
 
 	for i, ep := range p.Endpoints {
@@ -146,7 +149,7 @@ func (p *ProxyPool) Validate() error {
 		}
 
 		if p.Sticky.TTLMs != nil && *p.Sticky.TTLMs <= 0 {
-			return fmt.Errorf("sticky TTL must be positive")
+			return errors.New("sticky TTL must be positive")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `errors.New` preference rule to Go Rules section in `AGENTS.md`
- Fix all 22 existing `fmt.Errorf("static")` → `errors.New("static")` violations across 12 files

## Test plan
- [x] Full test suite passes (`go test ./... -race`)
- No behavioral change — purely mechanical replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)