### PR TITLE
Reconcile dogfooding scope and add Lode v0.4.1 compatibility notes

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -260,6 +260,10 @@ Expose policy selection without leaking complexity.
 
 ## Phase 6 — Dogfooding (Two Postures)
 
+> **Prerequisite**: v0.3.0 must be released before Phase 6 begins.
+> Phase 6 is a post-release validation exercise — Quarry is used E2E
+> on a real project, and feedback is captured as concrete follow-ups.
+
 ### Goal
 Validate Quarry across different ETL philosophies.
 
@@ -294,14 +298,14 @@ before adding event bus integrations.
 ### Deliverables
 - Lode upgrade to v0.4.1 with compatibility notes
 - CLI/Stats/Metrics hardening for run visibility and ingestion effects
-- Dogfooding focused on usability and integration stress testing
-- Clear v0.3.0 release readiness checklist and acceptance criteria
+- v0.3.0 release readiness checklist and acceptance criteria
+- Dogfooding prerequisites validated (CLI surface functional for real-project use)
 
 ### Mini-milestones
 - [ ] Lode dependency updated and validated against CONTRACT_LODE.md
 - [ ] CLI stats output includes policy effects and run outcome clarity
 - [ ] Metrics coverage for run lifecycle, ingestion drops, and executor failures
-- [ ] Dogfooding feedback captured and turned into concrete follow-ups
+- [ ] Dogfooding prerequisites met (Phase 6 can begin immediately post-release)
 
 ---
 

--- a/docs/RELEASE_READINESS_v0.3.0.md
+++ b/docs/RELEASE_READINESS_v0.3.0.md
@@ -15,7 +15,7 @@ Replace or remove once the long-term release process is defined.
 - [ ] Contract changes documented for any behavior changes
 - [ ] CHANGELOG.md Unreleased section finalized
 - [ ] PUBLIC_API.md and guides updated for user-facing changes
-- [ ] Lode upgrade decision recorded if in scope
+- [x] Lode upgrade decision recorded if in scope
 - [ ] Release workflow dry-run passes
 - [ ] Release notes drafted
 

--- a/docs/guides/lode-upgrade.md
+++ b/docs/guides/lode-upgrade.md
@@ -1,0 +1,71 @@
+# Lode Upgrade: v0.2.0 → v0.4.1
+
+This document records compatibility analysis for the Lode dependency
+upgrade shipped in Quarry v0.3.0.
+
+---
+
+## Upgrade Path
+
+Quarry previously pinned `github.com/justapithecus/lode v0.2.0`.
+The upgrade skips v0.3.0 and v0.4.0, landing on v0.4.1.
+
+### Lode v0.3.0 (docs/test only)
+- No API changes.
+- Documentation, examples, and streaming failure test coverage.
+
+### Lode v0.4.0 (compression + streaming API change)
+- **Breaking**: `StreamWriteRecords` parameter order changed to `(ctx, records, metadata)`.
+- Adds `NewZstdCompressor()` for zstd compression support.
+- New transitive dependency: `klauspost/compress v1.18.3`.
+
+### Lode v0.4.1 (S3 multipart hardening)
+- Conditional `CompleteMultipartUpload` for large S3 uploads (closes TOCTOU window).
+- No API changes.
+
+---
+
+## Impact on Quarry
+
+**Zero code changes required.**
+
+Quarry uses `Dataset.Write` (batch), not `StreamWriteRecords` (streaming).
+The v0.4.0 breaking change to `StreamWriteRecords` does not affect Quarry.
+
+| Surface | v0.2.0 → v0.4.1 Change | Quarry Impact |
+|---------|------------------------|---------------|
+| `lode.Store` interface | Identical (7 methods) | None |
+| `lode.Dataset` interface | Expanded (+StreamWrite, +StreamWriteRecords) | None — Quarry only uses `Write` |
+| `NewDataset` / `StoreFactory` / options | Identical signatures | None |
+| S3 `API` interface | Expanded (+4 multipart methods) | None — `*s3.Client` satisfies all |
+| S3 `New()` + `Config` | Identical | None |
+| HiveLayout / JSONL codec | Identical | None |
+| Partition layout | Unchanged (source/category/day/run_id/event_type) | None |
+
+---
+
+## CONTRACT_LODE.md Invariants
+
+All invariants verified post-upgrade:
+
+- Partition keys respected (source, category, day, run_id, event_type)
+- Append-only write semantics preserved
+- Chunks-before-commit ordering preserved
+- Offset tracking across batches preserved
+- Error classification (typed `StorageError` assertions) preserved
+- Record kinds (event, artifact_event, artifact_chunk, metrics) unchanged
+
+---
+
+## New Transitive Dependencies
+
+| Dependency | Version | Reason |
+|------------|---------|--------|
+| `klauspost/compress` | v1.18.3 | Zstd support in Lode (used internally for compression codec) |
+
+---
+
+## Rollback
+
+If issues arise, revert `go.mod` to pin `v0.2.0`. No data migration
+is needed — Lode's on-disk format is unchanged between v0.2.0 and v0.4.1.


### PR DESCRIPTION
## Summary
- Clarifies Phase 6 (dogfooding) as a post-release exercise — v0.3.0 delivers the prerequisites, Phase 6 validates them E2E on a real project.
- Adds Lode v0.2.0 → v0.4.1 compatibility notes documenting zero-impact upgrade path.
- Checks the Lode upgrade release gate.

## Highlights
- `docs/IMPLEMENTATION_PLAN.md`: Phase 6 prerequisite block added; v0.3.0 deliverables and milestones reworded to remove dogfooding-as-gate
- `docs/guides/lode-upgrade.md`: New file — upgrade path, compatibility matrix, CONTRACT_LODE invariant verification, rollback guidance
- `docs/RELEASE_READINESS_v0.3.0.md`: Lode upgrade gate checked off

## Test plan
- [ ] Verify IMPLEMENTATION_PLAN.md Phase 6 / v0.3.0 milestones no longer contradict
- [ ] Verify lode-upgrade.md compatibility matrix matches commit 8ee8c5f analysis
- [ ] Verify RELEASE_READINESS gate is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)