### PR TITLE
feat(lode): ✨ record policy name in event and artifact Lode records

### DIFF
--- a/quarry/cli/cmd/run.go
+++ b/quarry/cli/cmd/run.go
@@ -617,7 +617,7 @@ Quarry could not locate the executor. To fix:
 
 func buildPolicy(choice policyChoice, storageConfig storageChoice, source, category, runID string, startTime time.Time, collector *metrics.Collector) (policy.Policy, lode.Client, error) {
 	// Build storage sink
-	sink, client, err := buildStorageSink(storageConfig, source, category, runID, startTime, collector)
+	sink, client, err := buildStorageSink(storageConfig, source, category, runID, choice.name, startTime, collector)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create storage sink: %w", err)
 	}
@@ -644,7 +644,7 @@ func buildPolicy(choice policyChoice, storageConfig storageChoice, source, categ
 // Storage backend and path are required - no silent fallback to stub.
 // If collector is non-nil, wraps the sink with metrics instrumentation.
 // Returns the sink, the underlying client (for metrics persistence), and any error.
-func buildStorageSink(storageConfig storageChoice, source, category, runID string, startTime time.Time, collector *metrics.Collector) (policy.Sink, lode.Client, error) {
+func buildStorageSink(storageConfig storageChoice, source, category, runID, policy string, startTime time.Time, collector *metrics.Collector) (policy.Sink, lode.Client, error) {
 	// Build Lode config with partition keys
 	cfg := lode.Config{
 		Dataset:  "quarry",
@@ -652,6 +652,7 @@ func buildStorageSink(storageConfig storageChoice, source, category, runID strin
 		Category: category,
 		Day:      lode.DeriveDay(startTime),
 		RunID:    runID,
+		Policy:   policy,
 	}
 
 	var client lode.Client

--- a/quarry/lode/client_failure_test.go
+++ b/quarry/lode/client_failure_test.go
@@ -92,6 +92,7 @@ func TestLodeClient_FSDirectoryCreationFailure_NonExistentParent(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	// Failure can occur at factory creation OR at write time
@@ -151,6 +152,7 @@ func TestLodeClient_FSDirectoryCreationFailure_ReadOnlyParent(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	// Try to use a subdirectory of the read-only dir
@@ -210,6 +212,7 @@ func TestLodeClient_WriteFailure_DiskFull(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -257,6 +260,7 @@ func TestLodeClient_WriteFailure_PermissionDenied(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -290,6 +294,7 @@ func TestLodeClient_ChunkWriteFailure_DiskFull(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -328,6 +333,7 @@ func TestLodeClient_PartialWriteDetection_ChunksNotMarkedOnFailure(t *testing.T)
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -363,6 +369,7 @@ func TestLodeClient_PartialWriteDetection_OffsetsNotUpdatedOnFailure(t *testing.
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	// First, successfully write some chunks
@@ -416,6 +423,7 @@ func TestLodeClient_S3AuthFailure(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -453,6 +461,7 @@ func TestLodeClient_S3AccessDenied(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -499,6 +508,7 @@ func TestLodeClient_S3NetworkTimeout(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -536,6 +546,7 @@ func TestLodeClient_S3Throttling(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -603,6 +614,7 @@ func TestLodeClient_StorageError_ContainsOperationAndPath(t *testing.T) {
 				Category: "test-cat",
 				Day:      "2026-02-03",
 				RunID:    "run-1",
+				Policy:   "strict",
 			}
 
 			client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -663,6 +675,7 @@ func TestLodeClient_ErrorPropagation_EventWrite(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -706,6 +719,7 @@ func TestLodeClient_ErrorPropagation_ChunkWrite(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))
@@ -742,6 +756,7 @@ func TestLodeClient_NoSilentCorruption_FailedWritePreservesState(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	// Start with working store
@@ -803,6 +818,7 @@ func TestLodeClient_NoSilentCorruption_CommitFailurePreservesChunksState(t *test
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	// Start with working store
@@ -872,6 +888,7 @@ func TestLodeClient_ErrorChain_UnwrapPreservesOriginal(t *testing.T) {
 		Category: "test",
 		Day:      "2026-02-03",
 		RunID:    "run-1",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, FailingStoreFactory(store))

--- a/quarry/lode/client_test.go
+++ b/quarry/lode/client_test.go
@@ -18,6 +18,7 @@ func TestLodeClient_WriteEvents(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -62,6 +63,7 @@ func TestLodeClient_WriteArtifactEvent(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -111,6 +113,7 @@ func TestLodeClient_WriteChunks(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -147,6 +150,7 @@ func TestLodeClient_ChunkOffset(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	// Test that offsets are computed correctly per-artifact
@@ -184,6 +188,7 @@ func TestLodeClient_ChunkOffset_AcrossBatches(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -227,6 +232,7 @@ func TestLodeClient_CommitRequiresChunks(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -267,6 +273,7 @@ func TestLodeClient_CommitSucceedsWithChunks(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -311,6 +318,7 @@ func TestLodeClient_OffsetsResetAfterCommit(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -380,6 +388,7 @@ func TestLodeClient_CommitRejectsMissingArtifactID(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -433,6 +442,7 @@ func TestToEventRecord(t *testing.T) {
 		Category: "my-category",
 		Day:      "2026-02-03",
 		RunID:    "run-abc",
+		Policy:   "strict",
 	}
 
 	jobID := "job-xyz"
@@ -536,6 +546,7 @@ func TestLodeClient_WriteMetrics(t *testing.T) {
 		Category: "test-category",
 		Day:      "2026-02-03",
 		RunID:    "run-123",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, lode.NewMemoryFactory())
@@ -573,6 +584,7 @@ func TestToMetricsRecordMap(t *testing.T) {
 		Category: "my-category",
 		Day:      "2026-02-03",
 		RunID:    "run-abc",
+		Policy:   "strict",
 	}
 
 	snap := metrics.Snapshot{
@@ -645,6 +657,7 @@ func TestToArtifactCommitRecord(t *testing.T) {
 		Category: "my-category",
 		Day:      "2026-02-03",
 		RunID:    "run-abc",
+		Policy:   "strict",
 	}
 
 	e := &types.EventEnvelope{

--- a/quarry/lode/dataset_test.go
+++ b/quarry/lode/dataset_test.go
@@ -31,6 +31,7 @@ func TestNewReadDataset_WriteReadRoundTrip(t *testing.T) {
 		Category: "rt-category",
 		Day:      "2026-02-04",
 		RunID:    "run-rt",
+		Policy:   "strict",
 	}
 
 	client, err := NewLodeClientWithFactory(cfg, factory)

--- a/quarry/lode/records.go
+++ b/quarry/lode/records.go
@@ -109,6 +109,7 @@ func toEventRecordMap(e *types.EventEnvelope, cfg Config) map[string]any {
 		"source":           cfg.Source,
 		"category":         cfg.Category,
 		"day":              cfg.Day,
+		"policy":           cfg.Policy,
 	}
 	if e.JobID != nil {
 		m["job_id"] = *e.JobID
@@ -156,6 +157,7 @@ func toArtifactCommitRecordMap(e *types.EventEnvelope, cfg Config) map[string]an
 		"source":           cfg.Source,
 		"category":         cfg.Category,
 		"day":              cfg.Day,
+		"policy":           cfg.Policy,
 	}
 	if e.JobID != nil {
 		m["job_id"] = *e.JobID

--- a/quarry/lode/records_test.go
+++ b/quarry/lode/records_test.go
@@ -1,0 +1,76 @@
+package lode
+
+import (
+	"testing"
+
+	"github.com/justapithecus/quarry/types"
+)
+
+func TestToEventRecordMap_IncludesPolicy(t *testing.T) {
+	cfg := Config{
+		Dataset:  "quarry",
+		Source:   "test-source",
+		Category: "test-category",
+		Day:      "2026-02-06",
+		RunID:    "run-001",
+		Policy:   "strict",
+	}
+
+	envelope := &types.EventEnvelope{
+		ContractVersion: "1.0.0",
+		EventID:         "evt-1",
+		RunID:           "run-001",
+		Seq:             1,
+		Type:            types.EventTypeItem,
+		Ts:              "2026-02-06T12:00:00Z",
+		Payload:         map[string]any{"key": "value"},
+		Attempt:         1,
+	}
+
+	record := toEventRecordMap(envelope, cfg)
+
+	got, ok := record["policy"]
+	if !ok {
+		t.Fatal("record missing 'policy' key")
+	}
+	if got != "strict" {
+		t.Errorf("policy = %q, want %q", got, "strict")
+	}
+}
+
+func TestToArtifactCommitRecordMap_IncludesPolicy(t *testing.T) {
+	cfg := Config{
+		Dataset:  "quarry",
+		Source:   "test-source",
+		Category: "test-category",
+		Day:      "2026-02-06",
+		RunID:    "run-001",
+		Policy:   "buffered",
+	}
+
+	envelope := &types.EventEnvelope{
+		ContractVersion: "1.0.0",
+		EventID:         "evt-2",
+		RunID:           "run-001",
+		Seq:             2,
+		Type:            types.EventTypeArtifact,
+		Ts:              "2026-02-06T12:00:01Z",
+		Payload: map[string]any{
+			"artifact_id":  "art-001",
+			"name":         "screenshot.png",
+			"content_type": "image/png",
+			"size_bytes":   float64(1024),
+		},
+		Attempt: 1,
+	}
+
+	record := toArtifactCommitRecordMap(envelope, cfg)
+
+	got, ok := record["policy"]
+	if !ok {
+		t.Fatal("record missing 'policy' key")
+	}
+	if got != "buffered" {
+		t.Errorf("policy = %q, want %q", got, "buffered")
+	}
+}

--- a/quarry/lode/sink.go
+++ b/quarry/lode/sink.go
@@ -32,6 +32,8 @@ type Config struct {
 	Day string
 	// RunID is the partition key for run identifier.
 	RunID string
+	// Policy is the ingestion policy name (e.g. "strict", "buffered").
+	Policy string
 }
 
 // Sink is a Lode-backed implementation of policy.Sink.


### PR DESCRIPTION
## Summary

Add policy name to Lode event and artifact commit records so policy is discoverable from persisted data. Addresses Phase 5 milestone: "Policy recorded in run metadata" (IMPLEMENTATION_PLAN.md).

## Highlights

- Add `Policy` field to `lode.Config`
- Include `"policy"` key in `toEventRecordMap` and `toArtifactCommitRecordMap` output
- Wire policy name from CLI `policyChoice.name` through `buildStorageSink`
- No changes to `toChunkRecordMap` (binary data, no event metadata) or `toMetricsRecordMap` (already has `snap.Policy`)
- Legacy struct converters left as-is (not used with Lode)

## Test plan

- [x] New unit test: `TestToEventRecordMap_IncludesPolicy` — verifies `"policy": "strict"` in output map
- [x] New unit test: `TestToArtifactCommitRecordMap_IncludesPolicy` — verifies `"policy": "buffered"` in output map
- [x] `go test -race ./quarry/lode/...` passes
- [x] `go test -race ./quarry/cli/cmd/...` passes
- [x] `go test -race ./...` — full suite, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)