### PR TITLE
refactor(executor): ♻️ cleanup pass — extract helpers, reduce duplication

### DIFF
--- a/executor-node/src/loader.ts
+++ b/executor-node/src/loader.ts
@@ -95,17 +95,11 @@ export async function loadScript<Job = unknown>(scriptPath: string): Promise<Loa
   }
 
   // Validate optional hooks
-  if (!isOptionalFunction(mod.beforeRun)) {
-    throw new ScriptLoadError(scriptPath, 'beforeRun hook is not a function')
-  }
-  if (!isOptionalFunction(mod.afterRun)) {
-    throw new ScriptLoadError(scriptPath, 'afterRun hook is not a function')
-  }
-  if (!isOptionalFunction(mod.onError)) {
-    throw new ScriptLoadError(scriptPath, 'onError hook is not a function')
-  }
-  if (!isOptionalFunction(mod.cleanup)) {
-    throw new ScriptLoadError(scriptPath, 'cleanup hook is not a function')
+  const HOOK_NAMES = ['beforeRun', 'afterRun', 'onError', 'cleanup'] as const
+  for (const name of HOOK_NAMES) {
+    if (!isOptionalFunction(mod[name])) {
+      throw new ScriptLoadError(scriptPath, `${name} hook is not a function`)
+    }
   }
 
   // Cast through unknown since we've validated the shape above


### PR DESCRIPTION
## Summary

Declarative cleanup of executor-node source files after the puppeteer-extra feature landed. Extracts repeated patterns into composable helpers, reducing boilerplate without changing behavior. Net -18 lines across 3 files.

## Highlights

- **`errorMessage()`** — extracted from 7 inline `err instanceof Error ? err.message : String(err)` occurrences
- **`resolveModuleOrThrow()`** — collapses 4 identical try/catch blocks in `getPuppeteer()` into flat resolve-or-throw calls
- **`safeClose()`** — replaces 3 identical resource cleanup blocks in the finally block
- **`emitRunResult()`** — deduplicates run_result emission from success + crash paths
- **`isSinkFailure()`** — simplified from 3 branches to single expression: `return !(err instanceof TerminalEventError)`
- **Cache invalidation** — flattened nested if/else to early-return guard
- **Hook validation loop** in `loader.ts` — 4 repeated checks replaced with declarative `HOOK_NAMES` loop
- **`fatalError()`** in `bin/executor.ts` — collapses 3 repeated `stderr.write + process.exit(3)` catch blocks
- Removed unused `SinkAlreadyFailedError` import

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 109/109 tests pass (no test changes)
- [x] `pnpm run lint` — clean
- [x] `pnpm run bundle` — builds successfully (87.7 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)