### PR TITLE
refactor(executor-node): ♻️ share errorMessage helper in bin entrypoint

### DIFF
--- a/executor-node/src/bin/executor.ts
+++ b/executor-node/src/bin/executor.ts
@@ -24,7 +24,7 @@
  * @module
  */
 import type { ProxyEndpoint } from '@justapithecus/quarry-sdk'
-import { execute, parseRunMeta } from '../executor.js'
+import { errorMessage, execute, parseRunMeta } from '../executor.js'
 
 /**
  * Write an error message to stderr and exit with code 3 (invalid input).
@@ -119,7 +119,7 @@ async function main(): Promise<never> {
     }
     input = JSON.parse(stdinData)
   } catch (err) {
-    fatalError(`parsing stdin JSON: ${err instanceof Error ? err.message : String(err)}`)
+    fatalError(`parsing stdin JSON: ${errorMessage(err)}`)
   }
 
   if (input === null || typeof input !== 'object') {
@@ -133,7 +133,7 @@ async function main(): Promise<never> {
   try {
     run = parseRunMeta(inputObj)
   } catch (err) {
-    fatalError(`parsing run metadata: ${err instanceof Error ? err.message : String(err)}`)
+    fatalError(`parsing run metadata: ${errorMessage(err)}`)
   }
 
   // Extract job payload
@@ -147,7 +147,7 @@ async function main(): Promise<never> {
   try {
     proxy = parseProxy(inputObj)
   } catch (err) {
-    fatalError(`parsing proxy: ${err instanceof Error ? err.message : String(err)}`)
+    fatalError(`parsing proxy: ${errorMessage(err)}`)
   }
 
   // Execute
@@ -191,6 +191,6 @@ async function main(): Promise<never> {
 }
 
 main().catch((err) => {
-  process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.stderr.write(`Unexpected error: ${errorMessage(err)}\n`)
   process.exit(2)
 })

--- a/executor-node/src/executor.ts
+++ b/executor-node/src/executor.ts
@@ -68,7 +68,7 @@ async function resolveModule(name: string, scriptPath: string): Promise<Record<s
 /**
  * Extract a human-readable message from an unknown error value.
  */
-function errorMessage(err: unknown): string {
+export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 


### PR DESCRIPTION
## Summary

Export the existing `errorMessage()` helper from `executor.ts` and use it
in `bin/executor.ts`, eliminating 4 inline `err instanceof Error ? err.message : String(err)` patterns.

## Highlights

- Export `errorMessage()` from `executor.ts` (not added to public barrel — internal helper only)
- Replace 4 inline error extraction patterns in `bin/executor.ts` with `errorMessage(err)`
- No behavior change; all 109 tests pass

## Test plan

- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm run test` — 109/109 tests pass
- [x] `pnpm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)