### PR TITLE
fix(build): 🐛 stabilize embedded executor bundle sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,26 @@ jobs:
       - name: "🧪 Test"
         run: task test
 
+  bundle-freshness:
+    name: "📦 Bundle Freshness"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v4
+      - name: "🧰 Setup"
+        uses: jdx/mise-action@v2
+      - name: "📦 Install dependencies"
+        run: pnpm install
+      - name: "📦 Regenerate bundle"
+        run: task executor:bundle
+      - name: "🔍 Check for drift"
+        run: |
+          if ! git diff --exit-code quarry/executor/bundle/executor.mjs; then
+            echo "::error::Embedded executor bundle is stale. Run 'task executor:bundle' and commit the result."
+            exit 1
+          fi
+          echo "✅ Bundle is fresh"
+
   build:
     name: "🏗️ Build"
     runs-on: ubuntu-latest

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -86,8 +86,6 @@ tasks:
     deps: [ts:build]
     cmds:
       - pnpm -C executor-node run bundle
-      - mkdir -p quarry/executor/bundle
-      - cp executor-node/dist/bundle/executor.mjs quarry/executor/bundle/
 
   go:lint:
     desc: Lint Go module

--- a/executor-node/package.json
+++ b/executor-node/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x dist/bin/executor.js",
-    "bundle": "mkdir -p dist/bundle && tsx scripts/bundle.ts && chmod +x dist/bundle/executor.mjs",
+    "bundle": "mkdir -p dist/bundle ../quarry/executor/bundle && tsx scripts/bundle.ts && chmod +x ../quarry/executor/bundle/executor.mjs",
     "lint": "biome check .",
     "format": "biome check --write .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Eliminates dual-path bundle drift by writing the executor bundle directly
to the go:embed source path, removing the copy-based sync step, and adding
a CI freshness guard. Closes #74.

## Highlights

- `executor-node/scripts/bundle.ts` now writes directly to `quarry/executor/bundle/executor.mjs` (the go:embed source)
- Removed `mkdir -p` + `cp` sync step from `Taskfile.yaml` `executor:bundle` task
- Added `bundle-freshness` CI job that regenerates the bundle and fails if the tracked file diverges
- Regenerated stale committed bundle to reflect current source (post-cleanup PRs #76/#79)
- `meta.json` (esbuild analysis artifact) stays in `executor-node/dist/bundle/`

## Test plan

- [x] `task executor:bundle` — writes to canonical path
- [x] `task go:build` — Go binary builds with embedded bundle
- [x] Back-to-back bundle runs produce identical checksums (deterministic)
- [x] `task test` — all tests pass (172 SDK + 109 executor-node + all Go)
- [ ] CI `bundle-freshness` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)