### PR TITLE
feat(release): ✨ add cross-compiled binaries and dual npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,17 +109,63 @@ jobs:
         env:
           QUARRY_NO_SANDBOX: "1"
 
-  package:
-    name: "📦 Package"
+  cross-compile:
+    name: "🔨 Build (${{ matrix.goos }}/${{ matrix.goarch }})"
     runs-on: ubuntu-latest
     needs: [version_lockstep, lint, test, build, examples]
     if: ${{ needs.version_lockstep.result == 'success' }}
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
     steps:
       - name: "📥 Checkout"
         uses: actions/checkout@v4
       - name: "🧰 Setup"
         uses: jdx/mise-action@v2
-      - name: "📦 Package"
+      - name: "📦 Install dependencies"
+        run: pnpm install
+      - name: "📦 Bundle executor"
+        run: task executor:bundle
+      - name: "🔨 Build"
+        working-directory: quarry
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -o quarry ./cmd/quarry
+      - name: "📦 Archive"
+        run: |
+          mkdir -p dist
+          VERSION="${GITHUB_REF_NAME}"
+          ARCHIVE="quarry_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz"
+          tar -czf "dist/${ARCHIVE}" -C quarry quarry
+          sha256sum "dist/${ARCHIVE}" > "dist/${ARCHIVE}.sha256"
+      - name: "⬆️ Upload"
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
+
+  package:
+    name: "📦 Package"
+    runs-on: ubuntu-latest
+    needs: [cross-compile]
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v4
+      - name: "🧰 Setup"
+        uses: jdx/mise-action@v2
+      - name: "📦 Install dependencies"
+        run: pnpm install
+      - name: "📦 Package source & SDK"
         run: |
           mkdir -p dist
           VERSION="${GITHUB_REF_NAME}"
@@ -131,6 +177,17 @@ jobs:
           cd ..
           mv "sdk/${SDK_TARBALL}" "dist/quarry-sdk-${VERSION}.tgz"
           sha256sum "dist/quarry-sdk-${VERSION}.tgz" > "dist/quarry-sdk-${VERSION}.tgz.sha256"
+      - name: "⬇️ Download platform binaries"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist/
+          merge-multiple: true
+      - name: "📋 Generate checksums manifest"
+        run: |
+          cd dist
+          sha256sum quarry_*.tar.gz > checksums.txt
+          cat checksums.txt
       - name: "⬆️ Upload Artifacts"
         uses: actions/upload-artifact@v4
         with:
@@ -164,7 +221,7 @@ jobs:
           generate_release_notes: true
           files: dist/*
 
-  publish_npm:
+  publish_ghpr:
     name: "📦 Publish SDK (GitHub Packages)"
     runs-on: ubuntu-latest
     needs: [hold]
@@ -210,3 +267,28 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm publish --access restricted --no-git-checks
+
+  publish_npmjs:
+    name: "📦 Publish SDK (npmjs.org)"
+    runs-on: ubuntu-latest
+    needs: [hold]
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v4
+      - name: "🧰 Setup Node for npmjs"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.13.0"  # Matches mise.toml pin
+          registry-url: "https://registry.npmjs.org"
+          scope: "@justapithecus"
+      - name: "📦 Setup pnpm via Corepack"
+        run: |
+          EXPECTED_PNPM=$(jq -r '.packageManager' package.json | sed 's/pnpm@\([^+]*\).*/\1/')
+          echo "🔧 Preparing pnpm@${EXPECTED_PNPM} via Corepack"
+          corepack enable
+          corepack prepare "pnpm@${EXPECTED_PNPM}" --activate
+      - name: "📦 Publish"
+        working-directory: sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --registry https://registry.npmjs.org --no-git-checks

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -87,6 +87,19 @@ tasks:
     cmds:
       - pnpm -C executor-node run bundle
 
+  go:cross:
+    desc: Cross-compile quarry for all platforms
+    deps: [executor:bundle]
+    dir: quarry
+    cmds:
+      - |
+        mkdir -p dist
+        for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+          GOOS="${pair%/*}" GOARCH="${pair#*/}" CGO_ENABLED=0 \
+            go build -o "dist/quarry_${GOOS}_${GOARCH}" ./cmd/quarry
+          echo "✅ ${pair}"
+        done
+
   go:lint:
     desc: Lint Go module
     aliases: [go:l]


### PR DESCRIPTION
## Summary

Add cross-compiled platform binaries to GitHub releases for mise-based installation, and dual-publish the SDK to both GitHub Packages and npmjs.org.

## Highlights

- **Cross-compile matrix**: 4 platform targets (linux/darwin × amd64/arm64) with `CGO_ENABLED=0`, producing mise-compatible archives (`quarry_vX.Y.Z_os_arch.tar.gz`)
- **Package merge**: Source tarball, SDK tarball, and all platform binaries consolidated into a single release artifact set with `checksums.txt` manifest
- **Dual npm publishing**: `publish_ghpr` (GitHub Packages, restricted) + `publish_npmjs` (npmjs.org, public) — SDK available on both registries
- **Org-level secret**: npmjs publish uses `NPM_TOKEN` org secret — set once, shared across repos
- **Dev convenience**: `task go:cross` for local cross-compilation
- **mise install path**: `mise install github:justapithecus/quarry@X.Y.Z` will auto-detect the correct platform binary from release assets

## Setup required

Before first use of the npmjs publish job:
1. Create an npm **Automation** access token on npmjs.org (scoped to `@justapithecus`)
2. Add it as an **organization-level** secret named `NPM_TOKEN` at `github.com/organizations/justapithecus/settings/secrets/actions`

## Test plan

- [ ] CI passes (no runtime changes, workflow-only)
- [ ] Push a test tag (`v0.0.0-test.1`) to verify cross-compile matrix produces 4 platform archives
- [ ] Verify `checksums.txt` manifest in release assets
- [ ] Verify `mise install github:justapithecus/quarry@<version>` resolves correct binary
- [ ] Verify npmjs publish step runs (requires NPM_TOKEN secret)
- [ ] `task go:cross` produces 4 binaries locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)