### PR TITLE
feat(release): ✨ replace npmjs publish with JSR (OIDC, no tokens)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,27 +268,24 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm publish --access restricted --no-git-checks
 
-  publish_npmjs:
-    name: "📦 Publish SDK (npmjs.org)"
+  publish_jsr:
+    name: "📦 Publish SDK (JSR)"
     runs-on: ubuntu-latest
     needs: [hold]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: "📥 Checkout"
         uses: actions/checkout@v4
-      - name: "🧰 Setup Node for npmjs"
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24.13.0"  # Matches mise.toml pin
-          registry-url: "https://registry.npmjs.org"
-          scope: "@justapithecus"
-      - name: "📦 Setup pnpm via Corepack"
-        run: |
-          EXPECTED_PNPM=$(jq -r '.packageManager' package.json | sed 's/pnpm@\([^+]*\).*/\1/')
-          echo "🔧 Preparing pnpm@${EXPECTED_PNPM} via Corepack"
-          corepack enable
-          corepack prepare "pnpm@${EXPECTED_PNPM}" --activate
+      - name: "🧰 Setup"
+        uses: jdx/mise-action@v2
+      - name: "📦 Install dependencies"
+        run: pnpm install
+      - name: "🏗️ Build SDK"
+        run: pnpm -C sdk run build
       - name: "📦 Publish"
         working-directory: sdk
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --registry https://registry.npmjs.org --no-git-checks
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npx jsr publish --set-version "$VERSION"

--- a/sdk/jsr.json
+++ b/sdk/jsr.json
@@ -1,0 +1,7 @@
+{
+  "name": "@justapithecus/quarry-sdk",
+  "exports": "./dist/index.mjs",
+  "publish": {
+    "include": ["dist/", "README.md"]
+  }
+}


### PR DESCRIPTION
## Summary

Replace the npmjs.org SDK publish job with JSR publishing using OIDC authentication. No secrets, no tokens — GitHub Actions proves identity to JSR automatically.

## Highlights

- **Zero secrets**: OIDC via `id-token: write` permission replaces `NPM_TOKEN` — no org secret setup needed
- **Version injection**: `--set-version` reads from git tag at publish time, so `jsr.json` has no `version` field and no lockstep duplication
- **Built output**: Publishes `dist/` (JS + declarations) since SDK uses extensionless imports incompatible with JSR's module resolution; `publish.include` overrides `.gitignore`
- **Consumer install**: `npx jsr add @justapithecus/quarry-sdk` or configure JSR registry in `.npmrc`

## Setup required

Before first publish, create the `@justapithecus` scope on [jsr.io](https://jsr.io) and link the GitHub repo for OIDC trust.

## Test plan

- [ ] CI passes (no runtime changes)
- [ ] Verify `jsr.json` is valid: `cd sdk && npx jsr publish --dry-run`
- [ ] On next release tag, confirm JSR publish job succeeds with OIDC
- [ ] Verify package appears on `jsr.io/@justapithecus/quarry-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)