### PR TITLE
chore(release): 🔖 prepare v0.3.2 release

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.3.0.
+User-facing guide for Quarry v0.3.2.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -18,6 +18,46 @@ type-stripping. Node 23+ enables this by default. Node 22.6–22.x requires
 `--experimental-strip-types` flag (set via `NODE_OPTIONS`).
 
 Quarry is **TypeScript-first** and **ESM-only**.
+
+---
+
+## Installation
+
+### Via mise (recommended)
+
+```bash
+mise install github:justapithecus/quarry@0.3.2
+```
+
+Or pin in your `mise.toml`:
+
+```toml
+[tools]
+"github:justapithecus/quarry" = "0.3.2"
+```
+
+### SDK
+
+Install the SDK in your script project:
+
+```bash
+npx jsr add @justapithecus/quarry-sdk
+```
+
+Or via pnpm with GitHub Packages:
+
+```bash
+pnpm add @justapithecus/quarry-sdk
+```
+
+### From source
+
+```bash
+git clone https://github.com/justapithecus/quarry.git
+cd quarry
+pnpm install
+task build
+```
 
 ---
 
@@ -303,7 +343,7 @@ task build
 
 ---
 
-## Known Limitations (v0.3.0)
+## Known Limitations (v0.3.2)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -365,7 +405,15 @@ processing after runs complete, see [docs/guides/integration.md](docs/guides/int
 
 ```bash
 quarry version
-# 0.3.0 (commit: ...)
+# 0.3.2 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
+
+### Distribution Channels
+
+| Component | Channel | Install |
+|-----------|---------|---------|
+| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.3.2` |
+| SDK | JSR | `npx jsr add @justapithecus/quarry-sdk` |
+| SDK | GitHub Packages | `pnpm add @justapithecus/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 
 ---
 
+## Installation
+
+### CLI
+
+```bash
+mise install github:justapithecus/quarry@0.3.2
+```
+
+### SDK
+
+```bash
+npx jsr add @justapithecus/quarry-sdk
+```
+
+See [PUBLIC_API.md](PUBLIC_API.md) for full setup and usage guide.
+
+---
+
 ## What Quarry Is
 
 Quarry is:

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.3.1
+// Quarry Executor Bundle v0.3.2
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.3.1"
+const Version = "0.3.2"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -5,6 +5,10 @@ TypeScript SDK for writing Quarry extraction scripts.
 ## Installation
 
 ```bash
+# via JSR (recommended)
+npx jsr add @justapithecus/quarry-sdk
+
+# via GitHub Packages
 pnpm add @justapithecus/quarry-sdk
 ```
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
## Summary

Prepare v0.3.2 release with version bumps, installation docs, and distribution channel references.

## Highlights

- **Version bump**: 0.3.1 → 0.3.2 in `types/version.go`, `sdk/package.json`, executor bundle
- **Installation docs**: Added mise CLI install and JSR SDK install to README, PUBLIC_API.md, and SDK README
- **Distribution channels table**: PUBLIC_API.md now documents all three channels (GitHub Releases, JSR, GitHub Packages)
- **Version references**: Updated stale v0.3.0 references in PUBLIC_API.md

## What's new in v0.3.2

- Cross-compiled platform binaries in GitHub Releases (linux/darwin × amd64/arm64) (#82)
- JSR publishing with OIDC auth (no tokens) (#83)
- mise-compatible binary archive naming for `mise install github:justapithecus/quarry`

## Test plan

- [ ] `task version:lockstep` passes
- [ ] CI passes (lint, test, build, bundle-freshness, cli-parity)
- [ ] After merge: tag `v0.3.2`, verify release workflow produces platform binaries
- [ ] Verify JSR publish job succeeds (requires `@justapithecus` scope on jsr.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)