### PR TITLE
fix(sdk): 🐛 bump CONTRACT_VERSION to 0.3.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,10 @@ Quarry uses **lockstep versioning**:
 When releasing:
 1. Update `quarry/types/version.go`
 2. Update `sdk/package.json` version field to match
-3. Rebuild SDK (`pnpm exec tsdown` in sdk/)
-4. Commit as a single version bump
+3. Update `sdk/src/types/events.ts` `CONTRACT_VERSION` to match
+4. Rebuild SDK (`pnpm exec tsdown` in sdk/)
+5. Rebuild executor bundle (`task executor:bundle`)
+6. Commit as a single version bump
 
 ---
 

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1744,7 +1744,7 @@ import { dirname, resolve as resolve2 } from "node:path";
 
 // ../sdk/dist/index.mjs
 import { randomUUID } from "node:crypto";
-var CONTRACT_VERSION = "0.3.1";
+var CONTRACT_VERSION = "0.3.2";
 var TerminalEventError = class extends Error {
   constructor() {
     super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.3.1' as const
+export const CONTRACT_VERSION = '0.3.2' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================


### PR DESCRIPTION
## Summary

Fix contract version mismatch that caused all examples to fail with exit code 2 (executor crash). `CONTRACT_VERSION` in the SDK was still `0.3.1` while the runtime expected `0.3.2`.

## Highlights

- **Root cause**: `sdk/src/types/events.ts` `CONTRACT_VERSION` was not updated during the v0.3.2 version bump
- **Fix**: Bump `CONTRACT_VERSION` from `0.3.1` to `0.3.2`, rebuild SDK and executor bundle
- **Prevention**: Updated AGENTS.md release procedure to explicitly include `CONTRACT_VERSION` and executor bundle rebuild steps

## Test plan

- [x] `task examples` passes locally (5/5)
- [ ] CI passes (lint, test, build, bundle-freshness, examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)