### PR TITLE
fix(sdk): 🐛 update golden fixtures for contract_version 0.3.2

### DIFF
--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.3.1",
+    "contract_version": "0.3.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Golden test fixtures still referenced `contract_version: "0.3.1"` after the `CONTRACT_VERSION` bump in #85, causing CI and the v0.3.2 release workflow to fail.

## Highlights

- Update `simple-run.json` golden fixture (3 events) from `0.3.1` → `0.3.2`
- Update `artifact-run.json` golden fixture (4 events) from `0.3.1` → `0.3.2`

## Test plan

- [x] `pnpm -C sdk run test` — all 172 tests pass locally, including both golden tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)