### PR TITLE
feat(lode): ✨ add S3-compatible provider support (R2, MinIO)

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -222,11 +222,13 @@ quarry run [options]
 |------|-------------|
 | `--executor <path>` | Override executor path (auto-resolved by default) |
 
-**Storage flags (S3):**
+**Storage flags (S3 / S3-compatible):**
 
 | Flag | Description |
 |------|-------------|
 | `--storage-region <region>` | AWS region (uses default chain if omitted) |
+| `--storage-endpoint <url>` | Custom S3 endpoint URL (e.g. Cloudflare R2, MinIO) |
+| `--storage-s3-path-style` | Force path-style addressing (required by R2, MinIO) |
 
 ### Inspect Command
 
@@ -388,6 +390,23 @@ Uses AWS default credential chain. IAM permissions required:
 - `s3:PutObject`
 - `s3:GetObject`
 - `s3:ListBucket`
+
+### S3-Compatible Providers (R2, MinIO)
+
+Quarry supports S3-compatible storage providers via custom endpoint and path-style flags:
+
+```bash
+--storage-backend s3 \
+--storage-path my-bucket/quarry-data \
+--storage-endpoint https://ACCOUNT_ID.r2.cloudflarestorage.com \
+--storage-s3-path-style
+```
+
+Set credentials via environment variables:
+```bash
+export AWS_ACCESS_KEY_ID=<access-key>
+export AWS_SECRET_ACCESS_KEY=<secret-key>
+```
 
 ---
 

--- a/docs/CLI_PARITY.json
+++ b/docs/CLI_PARITY.json
@@ -140,6 +140,18 @@
           "type": "string",
           "required": false,
           "description": "AWS region for S3 backend (uses default credential chain if omitted)"
+        },
+        "storage-endpoint": {
+          "type": "string",
+          "required": false,
+          "description": "Custom S3 endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO)",
+          "dependsOn": ["storage-backend=s3"]
+        },
+        "storage-s3-path-style": {
+          "type": "bool",
+          "required": false,
+          "description": "Force path-style addressing for S3 (required by R2, MinIO)",
+          "dependsOn": ["storage-backend=s3"]
         }
       }
     },

--- a/docs/contracts/CONTRACT_LODE.md
+++ b/docs/contracts/CONTRACT_LODE.md
@@ -197,3 +197,17 @@ Lode must surface run metadata alongside stored events:
 - run outcome status
 
 Deduplication is explicitly out of scope and left to downstream consumers.
+
+---
+
+## S3-Compatible Provider Support
+
+The S3 storage backend supports S3-compatible providers (Cloudflare R2, MinIO, etc.)
+via custom endpoint and path-style addressing options.
+
+- **Custom endpoint**: overrides the default AWS S3 endpoint URL.
+- **Path-style addressing**: uses `endpoint/bucket/key` instead of `bucket.endpoint/key`.
+  Required by most S3-compatible providers.
+
+These are runtime configuration options passed via CLI flags (`--storage-endpoint`,
+`--storage-s3-path-style`). They do not affect partition layout or record format.


### PR DESCRIPTION
## Summary

Add `--storage-endpoint` and `--storage-s3-path-style` CLI flags to support S3-compatible storage providers (Cloudflare R2, MinIO, etc.). This unblocks using Quarry with non-AWS object storage, which is a prerequisite for the codename crawler → Quarry migration.

## Highlights

- Add `Endpoint` and `UsePathStyle` fields to `S3Config` struct in `client_s3.go`
- Wire `BaseEndpoint` and `UsePathStyle` through to `s3.NewFromConfig` via functional options
- Add `--storage-endpoint` (string) and `--storage-s3-path-style` (bool) CLI flags
- Warn when S3-specific flags are used with the `fs` backend
- Add R2 usage example to CLI help text
- Update `CLI_PARITY.json`, `PUBLIC_API.md`, and `CONTRACT_LODE.md`

## Test plan

- [x] `go test ./...` — all tests pass (including CLI parity test)
- [ ] Manual test with R2 endpoint after v0.3.3 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)