### PR TITLE
fix(release): 🐛 publish TypeScript source to JSR instead of dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,8 +282,6 @@ jobs:
         uses: jdx/mise-action@v2
       - name: "📦 Install dependencies"
         run: pnpm install
-      - name: "🏗️ Build SDK"
-        run: pnpm -C sdk run build
       - name: "📦 Publish"
         working-directory: sdk
         run: |

--- a/sdk/jsr.json
+++ b/sdk/jsr.json
@@ -1,7 +1,16 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "exports": "./dist/index.mjs",
+  "license": "Apache-2.0",
+  "exports": "./src/index.ts",
   "publish": {
-    "include": ["dist/", "README.md"]
+    "include": [
+      "src/**/*.ts",
+      "jsr.json",
+      "README.md"
+    ],
+    "exclude": [
+      "**/*.test.ts",
+      "**/*.spec.ts"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

JSR natively supports TypeScript — publishing compiled dist was unnecessary
and lost type information. This switches to publishing source directly.

## Highlights

- Change `jsr.json` exports from `./dist/index.mjs` to `./src/index.ts`
- Update publish include to `src/**/*.ts` with test exclusions
- Remove redundant "Build SDK" step from release workflow
- Add `license` field to `jsr.json`

## Test plan

- [ ] Verify `npx jsr publish --dry-run` in `sdk/` succeeds
- [ ] Confirm release workflow YAML is valid
- [ ] Verify published package resolves types correctly on JSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)