### PR TITLE
docs(lode): 📝 add S3-compatible provider docs to guides

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -350,7 +350,7 @@ task build
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
 3. **No streaming reads**: Artifacts must fit in memory
-4. **S3 is experimental**: Requires explicit opt-in; no transactional guarantees across writes
+4. **S3 is experimental**: S3 and S3-compatible providers (R2, MinIO) are supported but experimental; no transactional guarantees across writes
 5. **No job scheduling**: Quarry is an execution runtime, not a scheduler
 6. **Puppeteer required**: All scripts run in a browser context
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -115,6 +115,11 @@ Optional flags:
 - `--proxy-domain <domain>` (when sticky scope = domain)
 - `--proxy-origin <origin>` (when sticky scope = origin, format: scheme://host:port)
 
+Storage flags (S3 / S3-compatible):
+- `--storage-region <region>` (AWS region, uses default chain if omitted)
+- `--storage-endpoint <url>` (custom S3 endpoint for R2, MinIO, etc.)
+- `--storage-s3-path-style` (force path-style addressing, required by R2/MinIO)
+
 Advanced flags:
 - `--executor <path>` (auto-resolved by default; override for troubleshooting)
 
@@ -150,6 +155,20 @@ quarry run \
   --proxy-pool residential_sticky \
   --proxy-domain example.com \
   --job '{"source":"demo"}'
+```
+
+S3-compatible storage example (Cloudflare R2):
+
+```
+quarry run \
+  --script ./my-script.ts \
+  --run-id run-001 \
+  --source my-source \
+  --storage-backend s3 \
+  --storage-path my-bucket/quarry \
+  --storage-endpoint https://ACCOUNT_ID.r2.cloudflarestorage.com \
+  --storage-s3-path-style \
+  --job '{"url":"https://example.com"}'
 ```
 
 #### Job Payload Contract

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -55,6 +55,8 @@ command reference.
 | `--storage-backend` | `fs` or `s3` | Backend type |
 | `--storage-path` | string | `fs`: local directory; `s3`: `bucket/optional-prefix` |
 | `--storage-region` | string | AWS region (S3 only; uses default credential chain) |
+| `--storage-endpoint` | string | Custom S3 endpoint URL (for R2, MinIO, etc.) |
+| `--storage-s3-path-style` | bool | Force path-style addressing (required by R2, MinIO) |
 
 ### Policy
 
@@ -194,6 +196,9 @@ Resolution order:
 
 Set `--storage-region` if the bucket is not in your SDK's default region.
 
+For S3-compatible providers (R2, MinIO), set credentials via environment
+variables and use `--storage-endpoint` to point at the provider's endpoint.
+
 ---
 
 ## Configuration Flow
@@ -241,6 +246,25 @@ quarry run \
   --policy buffered \
   --buffer-events 500 \
   --buffer-bytes 10485760
+```
+
+### S3-compatible provider (Cloudflare R2)
+
+```bash
+quarry run \
+  --script ./my-script.ts \
+  --run-id run-001 \
+  --source my-source \
+  --storage-backend s3 \
+  --storage-path my-bucket/quarry \
+  --storage-endpoint https://ACCOUNT_ID.r2.cloudflarestorage.com \
+  --storage-s3-path-style
+```
+
+Credentials via environment variables:
+```bash
+export AWS_ACCESS_KEY_ID=<r2-access-key>
+export AWS_SECRET_ACCESS_KEY=<r2-secret-key>
 ```
 
 ### Proxy with stealth in CI

--- a/quarry/cli/cmd/run.go
+++ b/quarry/cli/cmd/run.go
@@ -74,7 +74,7 @@ EXAMPLES:
 
 ADVANCED:
   # Override executor path (troubleshooting)
-  quarry run --script ./script.ts --run-id run-005 --source my-source \
+  quarry run --script ./script.ts --run-id run-006 --source my-source \
     --storage-backend fs --storage-path ./data \
     --executor /custom/path/to/executor.js`,
 		Flags: []cli.Flag{


### PR DESCRIPTION
## Summary

Reconcile `cli.md` and `configuration.md` with the S3 endpoint and
path-style flags added in #87. Ensures all user-facing docs reference
the new R2/MinIO support.

## Highlights

- Add storage flags section and R2 example to `docs/guides/cli.md`
- Add endpoint/path-style rows and R2 recipe to `docs/guides/configuration.md`
- Note S3-compatible credential setup in AWS credentials section
- Update Known Limitations in `PUBLIC_API.md` to mention R2/MinIO
- Fix duplicate `run-005` → `run-006` in `run.go` usage text

## Test plan

- [ ] Verify all Go tests pass (`go test ./...`)
- [ ] Review docs render correctly on GitHub
- [ ] Confirm CLI parity test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)