### PR TITLE
docs(release): 📝 add changelog entries for v0.3.1–v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,54 @@ _No unreleased changes._
 
 ---
 
+## [0.3.3] - 2026-02-07
+
+### Added
+
+- **Storage**: S3-compatible provider support — new `--storage-endpoint` and `--storage-s3-path-style` CLI flags for Cloudflare R2, MinIO, and other S3-compatible backends (#87)
+- **Docs**: S3-compatible storage flags and R2 examples added to cli.md, configuration.md, and PUBLIC_API.md (#89)
+- **Docs**: S3-compatible provider support section added to CONTRACT_LODE.md (#87)
+
+### Fixed
+
+- **Release**: JSR now publishes TypeScript source instead of compiled dist, preserving full type information (#88)
+- **CLI**: Fixed duplicate run-id in usage text (#89)
+
+---
+
+## [0.3.2] - 2026-02-07
+
+### Added
+
+- **Release**: Cross-compiled platform binaries (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64) included in GitHub Releases (#82)
+- **Release**: mise install support — `mise install github:justapithecus/quarry@<version>` (#82)
+- **Release**: JSR publishing via OIDC (zero-secret) — `npx jsr add @justapithecus/quarry-sdk` (#83)
+- **Release**: Dual SDK distribution on JSR (public) and GitHub Packages (restricted) (#82, #83)
+- **Release**: Checksums manifest (`checksums.txt`) included in every release (#82)
+- **Docs**: Installation docs updated across README, PUBLIC_API.md, and SDK README (#82)
+
+---
+
+## [0.3.1] - 2026-02-06
+
+### Added
+
+- **Executor**: puppeteer-extra support with stealth and adblocker plugins (#75)
+  - Stealth enabled by default (`QUARRY_STEALTH=0` to disable)
+  - Adblocker opt-in via `QUARRY_ADBLOCKER=1`
+  - No-sandbox mode for CI via `QUARRY_NO_SANDBOX=1`
+- **Docs**: Consolidated configuration reference (`docs/guides/configuration.md`) (#81)
+
+### Changed
+
+- **Refactor**: Cleanup passes across SDK, executor, and Go runtime — extract helpers, reduce duplication, declarative validation (#76, #77, #78, #79)
+
+### Fixed
+
+- **Build**: Stabilized embedded executor bundle sync (#80)
+
+---
+
 ## [0.3.0] - 2026-02-06
 
 ### Added
@@ -141,6 +189,9 @@ _No unreleased changes._
 
 ---
 
+[0.3.3]: https://github.com/justapithecus/quarry/releases/tag/v0.3.3
+[0.3.2]: https://github.com/justapithecus/quarry/releases/tag/v0.3.2
+[0.3.1]: https://github.com/justapithecus/quarry/releases/tag/v0.3.1
 [0.3.0]: https://github.com/justapithecus/quarry/releases/tag/v0.3.0
 [0.2.2]: https://github.com/justapithecus/quarry/releases/tag/v0.2.2
 [0.2.1]: https://github.com/justapithecus/quarry/releases/tag/v0.2.1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:justapithecus/quarry@0.3.2
+mise install github:justapithecus/quarry@0.3.3
 ```
 
 ### SDK

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,23 +1,19 @@
-# Support Posture — Quarry v0.2.1
+# Support Posture — Quarry v0.3.3
 
-This document defines support expectations for Quarry v0.2.1.
+This document defines support expectations for Quarry v0.3.3.
 
 ---
 
 ## Maturity Level
 
-**v0.2.1 is an early release.** APIs and behaviors may change in subsequent
+**v0.3.3 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.2.1._
-
-### Fixed in v0.2.1
-
-- **IPC Race Condition** ([#56](https://github.com/justapithecus/quarry/issues/56)): Fixed issue where fast-completing scripts intermittently reported `executor_crash` outcome. Upgrade to v0.2.1 to resolve.
+_No known issues in v0.3.3._
 
 ---
 
@@ -127,12 +123,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.2.0 (commit: ...)
+# 0.3.3 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.2.0 is provided "as is" without warranty of any kind.
+Quarry v0.3.3 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,10 +13,10 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.2.2)
-- Latest release: v0.2.2 (see CHANGELOG.md).
-- Unreleased section: empty.
-- Next decision: define v0.3.0 scope and Lode upgrade path.
+## Current Status (as of v0.3.3)
+- Latest release: v0.3.3 (see CHANGELOG.md).
+- Phases 0–5 complete. Phase 6 (dogfooding) in progress.
+- v0.3.3 adds S3-compatible provider support (R2, MinIO).
 
 ---
 


### PR DESCRIPTION
## Summary

Backfill missing CHANGELOG.md entries for v0.3.1, v0.3.2, and v0.3.3 and fix stale version references across README.md, SUPPORT.md, and IMPLEMENTATION_PLAN.md.

## Highlights

- **CHANGELOG.md**: Add entries for v0.3.1 (puppeteer-extra, refactors), v0.3.2 (cross-compiled binaries, JSR), v0.3.3 (S3-compatible providers)
- **README.md**: Update mise install from v0.3.2 → v0.3.3
- **SUPPORT.md**: Update from v0.2.1 → v0.3.3 throughout (title, maturity, known issues, version example, warranty)
- **IMPLEMENTATION_PLAN.md**: Update current status from v0.2.2 → v0.3.3

## Test plan

- [x] All Go tests pass
- [ ] Review changelog entries match actual release contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)