### PR TITLE
chore(release): 🔖 prepare v0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ _No unreleased changes._
 
 ---
 
+## [0.3.4] - 2026-02-07
+
+### Fixed
+
+- **Lode**: Fixed nil-map panic in S3 client constructor — `NewLodeS3Client` failed to initialize artifact offset and chunk-tracking maps, causing runtime panic on first `WriteChunks` call (#92)
+
+### Changed
+
+- **Lode**: Extracted shared `newClient()` constructor helper to prevent future initialization drift between FS and S3 client paths (#92)
+
+### Added
+
+- **Testing**: Regression test `TestNewClient_InitializesMaps` guards against nil-map constructor bugs (#92)
+
+---
+
 ## [0.3.3] - 2026-02-07
 
 ### Added
@@ -189,6 +205,7 @@ _No unreleased changes._
 
 ---
 
+[0.3.4]: https://github.com/justapithecus/quarry/releases/tag/v0.3.4
 [0.3.3]: https://github.com/justapithecus/quarry/releases/tag/v0.3.3
 [0.3.2]: https://github.com/justapithecus/quarry/releases/tag/v0.3.2
 [0.3.1]: https://github.com/justapithecus/quarry/releases/tag/v0.3.1

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.3.3.
+User-facing guide for Quarry v0.3.4.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,14 +26,14 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:justapithecus/quarry@0.3.3
+mise install github:justapithecus/quarry@0.3.4
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:justapithecus/quarry" = "0.3.3"
+"github:justapithecus/quarry" = "0.3.4"
 ```
 
 ### SDK
@@ -345,7 +345,7 @@ task build
 
 ---
 
-## Known Limitations (v0.3.3)
+## Known Limitations (v0.3.4)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -424,7 +424,7 @@ processing after runs complete, see [docs/guides/integration.md](docs/guides/int
 
 ```bash
 quarry version
-# 0.3.3 (commit: ...)
+# 0.3.4 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -433,6 +433,6 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.3.3` |
+| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.3.4` |
 | SDK | JSR | `npx jsr add @justapithecus/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @justapithecus/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:justapithecus/quarry@0.3.3
+mise install github:justapithecus/quarry@0.3.4
 ```
 
 ### SDK

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.3.3
+# Support Posture — Quarry v0.3.4
 
-This document defines support expectations for Quarry v0.3.3.
+This document defines support expectations for Quarry v0.3.4.
 
 ---
 
 ## Maturity Level
 
-**v0.3.3 is an early release.** APIs and behaviors may change in subsequent
+**v0.3.4 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.3.3._
+_No known issues in v0.3.4._
 
 ---
 
@@ -123,12 +123,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.3.3 (commit: ...)
+# 0.3.4 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.3.3 is provided "as is" without warranty of any kind.
+Quarry v0.3.4 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,10 +13,10 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.3.3)
-- Latest release: v0.3.3 (see CHANGELOG.md).
+## Current Status (as of v0.3.4)
+- Latest release: v0.3.4 (see CHANGELOG.md).
 - Phases 0–5 complete. Phase 6 (dogfooding) in progress.
-- v0.3.3 adds S3-compatible provider support (R2, MinIO).
+- v0.3.4 adds S3-compatible provider support (R2, MinIO).
 
 ---
 

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.3.3
+// Quarry Executor Bundle v0.3.4
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -1744,7 +1744,7 @@ import { dirname, resolve as resolve2 } from "node:path";
 
 // ../sdk/dist/index.mjs
 import { randomUUID } from "node:crypto";
-var CONTRACT_VERSION = "0.3.3";
+var CONTRACT_VERSION = "0.3.4";
 var TerminalEventError = class extends Error {
   constructor() {
     super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.3.3"
+const Version = "0.3.4"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.3.3' as const
+export const CONTRACT_VERSION = '0.3.4' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.3.3",
+    "contract_version": "0.3.4",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Patch release fixing nil-map panic in Lode S3 client constructor discovered during dogfooding (Phase 6). Includes constructor refactor and regression test.

## Highlights

- **Fix**: `NewLodeS3Client` failed to initialize `offsets` and `chunksSeen` maps, causing runtime panic on first `WriteChunks` call (#92)
- **Refactor**: Extracted shared `newClient()` constructor helper — all client constructors (FS, factory, S3) now share a single initialization path
- **Test**: `TestNewClient_InitializesMaps` regression test guards against future constructor drift
- Lockstep version bump: `types/version.go`, `sdk/package.json`, `CONTRACT_VERSION`, golden fixtures
- CHANGELOG.md entry for v0.3.4

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All SDK tests pass (172 tests)
- [x] All executor-node tests pass (109 tests)
- [x] Version lockstep verified
- [x] SDK + executor bundle rebuilt
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)