### PR TITLE
docs(proxy): 📝 add recency window contract and v0.4.0 roadmap

### DIFF
--- a/docs/guides/proxy.md
+++ b/docs/guides/proxy.md
@@ -107,6 +107,39 @@ corresponding input, the CLI will warn and fall back to other sticky inputs.
 - Secure RNG used
 - Suitable for large pools
 
+#### Recency Window (optional)
+
+Set `recency_window` on a pool to avoid immediately reusing endpoints:
+
+```yaml
+proxies:
+  rotating_pool:
+    strategy: random
+    recency_window: 3
+    endpoints:
+      - protocol: http
+        host: proxy1.example.com
+        port: 8080
+      - protocol: http
+        host: proxy2.example.com
+        port: 8080
+      - protocol: http
+        host: proxy3.example.com
+        port: 8080
+      - protocol: http
+        host: proxy4.example.com
+        port: 8080
+      - protocol: http
+        host: proxy5.example.com
+        port: 8080
+```
+
+With `recency_window: 3`, the last 3 selected endpoints are excluded from the candidate pool. This prevents immediate reuse without sacrificing randomness.
+
+If the window is >= the number of endpoints, selection degrades to LRU (least-recently-used) ordering — effectively round-robin-like but without a fixed sequence.
+
+Only applies to the `random` strategy; ignored for `round_robin` and `sticky`.
+
 ### Sticky
 
 - Stable mapping by sticky key


### PR DESCRIPTION
## Summary

Adds the contract semantics, user guide, and implementation roadmap for proxy recency window — an opt-in `recency_window` pool option that prevents the `random` strategy from immediately reusing endpoints. Motivated by a prospective migration customer needing recency-aware rotation.

Docs-only change. Implementation is planned for v0.4.0.

## Highlights

- **CONTRACT_PROXY.md**: `recency_window` in data model, validation rules (hard: must be positive; soft: warn on non-random), selection semantics (ring buffer, LRU fallback, commit-only advancement)
- **proxy.md guide**: user-facing section with YAML config example, behavior description, and LRU degradation note
- **IMPLEMENTATION_PLAN.md**: v0.4.0 roadmap with Phase 1 (in-memory recency) and Phase 2 (pluggable backend with Redis, deferred)

## Test plan

- [x] Docs-only — no code changes, no tests affected
- [ ] CI passes (lint, build, test unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)