### PR TITLE
feat(proxy): ✨ add recency window for random proxy selection

### DIFF
--- a/quarry/cli/reader/stub.go
+++ b/quarry/cli/reader/stub.go
@@ -64,6 +64,8 @@ func (r *StubReader) InspectProxy(poolName string) *InspectProxyPoolResponse {
 		Runtime: ProxyRuntime{
 			RoundRobinIndex: 1,
 			StickyEntries:   5,
+			RecencyWindow:   3,
+			RecencyFill:     2,
 			LastUsedAt:      &now,
 		},
 	}

--- a/quarry/cli/reader/types.go
+++ b/quarry/cli/reader/types.go
@@ -46,6 +46,8 @@ type ProxySticky struct {
 type ProxyRuntime struct {
 	RoundRobinIndex int        `json:"round_robin_index"`
 	StickyEntries   int        `json:"sticky_entries"`
+	RecencyWindow   int        `json:"recency_window"`
+	RecencyFill     int        `json:"recency_fill"`
 	LastUsedAt      *time.Time `json:"last_used_at"`
 }
 

--- a/sdk/src/proxy.ts
+++ b/sdk/src/proxy.ts
@@ -206,6 +206,26 @@ export function validateProxyPool(pool: ProxyPool): ProxyValidationResult {
     }
   }
 
+  // Recency window validation
+  if (pool.recencyWindow !== undefined) {
+    if (
+      typeof pool.recencyWindow !== 'number' ||
+      !Number.isInteger(pool.recencyWindow) ||
+      pool.recencyWindow <= 0
+    ) {
+      errors.push(validationError('recencyWindow', 'Recency window must be a positive integer'))
+    }
+
+    if (pool.strategy !== 'random') {
+      warnings.push(
+        validationWarning(
+          'recencyWindow',
+          'recency_window is set but strategy is not "random"; recency_window only applies to random strategy'
+        )
+      )
+    }
+  }
+
   return buildValidationResult(errors, warnings)
 }
 

--- a/sdk/src/types/proxy.ts
+++ b/sdk/src/types/proxy.ts
@@ -80,6 +80,9 @@ export type ProxyPool = {
   readonly endpoints: readonly ProxyEndpoint[]
   /** Optional sticky configuration (only valid when strategy is 'sticky') */
   readonly sticky?: ProxySticky
+  /** Number of recently-used endpoints to exclude from random selection.
+   *  Only meaningful when strategy is 'random'. */
+  readonly recencyWindow?: number
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds an opt-in `recency_window` pool option that prevents the `random` strategy from immediately reusing proxy endpoints. Motivated by a prospective migration customer needing recency-aware rotation. This is Phase 1 of the v0.4.0 proxy rotation roadmap (contract and guide were merged in #95).

## Highlights

- **Go types** (`quarry/types/proxy.go`): `RecencyWindow *int` on `ProxyPool`, hard validation (must be positive), soft warning (non-random strategy)
- **Selector** (`quarry/proxy/selector.go`): ring buffer in `poolState`, recency-aware `selectRandom` with LRU fallback when window >= endpoint count, peek/commit semantics preserved
- **SDK** (`sdk/src/types/proxy.ts`, `sdk/src/proxy.ts`): `recencyWindow` type field + validation in `validateProxyPool`
- **Reader** (`quarry/cli/reader/`): `RecencyWindow`/`RecencyFill` in `ProxyRuntime` struct and stub
- **Tests**: 5 new selector tests (avoidance, LRU fallback, peek no-update, nil regression, stats progression) + 5 new type tests (validation + warnings)

## Test plan

- [x] `go test ./types/...` — type validation and warning tests pass
- [x] `go test ./proxy/...` — all 16 selector tests pass (11 existing + 5 new)
- [x] `go test ./...` — full Go suite green
- [x] `pnpm -C sdk run typecheck` — SDK types compile
- [x] `pnpm -C sdk run test` — all 172 SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)