### PR TITLE
feat(cli): ✨ add --storage-dataset flag to override Lode dataset ID

### DIFF
--- a/docs/CLI_PARITY.json
+++ b/docs/CLI_PARITY.json
@@ -125,6 +125,12 @@
           "required": false,
           "description": "Origin for sticky scope derivation (when scope=origin, format: scheme://host:port)"
         },
+        "storage-dataset": {
+          "type": "string",
+          "required": false,
+          "default": "quarry",
+          "description": "Lode dataset ID (overrides default \"quarry\")"
+        },
         "storage-backend": {
           "type": "string",
           "required": true,
@@ -365,6 +371,12 @@
         },
         "metrics": {
           "flags": {
+            "storage-dataset": {
+              "type": "string",
+              "required": false,
+              "default": "quarry",
+              "description": "Lode dataset ID (default: \"quarry\")"
+            },
             "format": {
               "type": "string",
               "aliases": ["f"],

--- a/docs/contracts/CONTRACT_CLI.md
+++ b/docs/contracts/CONTRACT_CLI.md
@@ -260,6 +260,7 @@ Response must include:
 Returns the most recent metrics snapshot.
 
 Optional flags:
+- `--storage-dataset=<name>` — Lode dataset ID (default: `"quarry"`)
 - `--storage-backend=fs|s3` — storage backend for Lode reads
 - `--storage-path=<path>` — storage path (fs: directory, s3: bucket/prefix)
 - `--storage-region=<region>` — AWS region for S3 backend

--- a/docs/contracts/CONTRACT_LODE.md
+++ b/docs/contracts/CONTRACT_LODE.md
@@ -20,7 +20,9 @@ Non-goals:
 
 ## Dataset Identity
 
-Quarry writes to a fixed Lode dataset ID: `quarry`.
+Quarry writes to a Lode dataset ID that defaults to `quarry`.
+The Lode dataset ID can be overridden via `--storage-dataset` on `quarry run`
+and `quarry stats metrics`.
 
 This dataset ID is a global container and is **not** the same as Quarry's
 logical `category` partition key.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -115,7 +115,8 @@ Optional flags:
 - `--proxy-domain <domain>` (when sticky scope = domain)
 - `--proxy-origin <origin>` (when sticky scope = origin, format: scheme://host:port)
 
-Storage flags (S3 / S3-compatible):
+Storage flags:
+- `--storage-dataset <name>` (Lode dataset ID, default: `"quarry"`)
 - `--storage-region <region>` (AWS region, uses default chain if omitted)
 - `--storage-endpoint <url>` (custom S3 endpoint for R2, MinIO, etc.)
 - `--storage-s3-path-style` (force path-style addressing, required by R2/MinIO)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -52,6 +52,7 @@ command reference.
 
 | Flag | Type | Purpose |
 |------|------|---------|
+| `--storage-dataset` | string | Lode dataset ID (default: `"quarry"`) |
 | `--storage-backend` | `fs` or `s3` | Backend type |
 | `--storage-path` | string | `fs`: local directory; `s3`: `bucket/optional-prefix` |
 | `--storage-region` | string | AWS region (S3 only; uses default credential chain) |

--- a/quarry/cli/cmd/inspect.go
+++ b/quarry/cli/cmd/inspect.go
@@ -30,8 +30,8 @@ func inspectRunCommand() *cli.Command {
 		Name:      "run",
 		Usage:     "Inspect a run by ID",
 		ArgsUsage: "<run-id>",
-		Flags:     TUIReadOnlyFlags(),
-		Action:    inspectRunAction,
+		Flags: TUIReadOnlyFlags(),
+		Action: inspectRunAction,
 	}
 }
 
@@ -62,8 +62,8 @@ func inspectJobCommand() *cli.Command {
 		Name:      "job",
 		Usage:     "Inspect a job by ID",
 		ArgsUsage: "<job-id>",
-		Flags:     TUIReadOnlyFlags(),
-		Action:    inspectJobAction,
+		Flags: TUIReadOnlyFlags(),
+		Action: inspectJobAction,
 	}
 }
 
@@ -90,8 +90,8 @@ func inspectTaskCommand() *cli.Command {
 		Name:      "task",
 		Usage:     "Inspect a task by ID",
 		ArgsUsage: "<task-id>",
-		Flags:     TUIReadOnlyFlags(),
-		Action:    inspectTaskAction,
+		Flags: TUIReadOnlyFlags(),
+		Action: inspectTaskAction,
 	}
 }
 

--- a/quarry/lode/dataset.go
+++ b/quarry/lode/dataset.go
@@ -13,9 +13,9 @@ import (
 
 // NewReadDataset creates a Lode Dataset for reading.
 // Uses the same codec and layout as the write path to ensure compatibility.
-func NewReadDataset(factory lode.StoreFactory) (lode.Dataset, error) {
+func NewReadDataset(dataset string, factory lode.StoreFactory) (lode.Dataset, error) {
 	return lode.NewDataset(
-		lode.DatasetID("quarry"),
+		lode.DatasetID(dataset),
 		factory,
 		lode.WithHiveLayout("source", "category", "day", "run_id", "event_type"),
 		lode.WithCodec(lode.NewJSONLCodec()),
@@ -23,13 +23,13 @@ func NewReadDataset(factory lode.StoreFactory) (lode.Dataset, error) {
 }
 
 // NewReadDatasetFS creates a read Dataset with filesystem storage.
-func NewReadDatasetFS(rootPath string) (lode.Dataset, error) {
-	return NewReadDataset(lode.NewFSFactory(rootPath))
+func NewReadDatasetFS(dataset, rootPath string) (lode.Dataset, error) {
+	return NewReadDataset(dataset, lode.NewFSFactory(rootPath))
 }
 
 // NewReadDatasetS3 creates a read Dataset with S3 storage.
 // Uses AWS SDK default credential chain (env vars, shared config, IAM role).
-func NewReadDatasetS3(s3cfg S3Config) (lode.Dataset, error) {
+func NewReadDatasetS3(dataset string, s3cfg S3Config) (lode.Dataset, error) {
 	if err := s3cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func NewReadDatasetS3(s3cfg S3Config) (lode.Dataset, error) {
 		})
 	}
 
-	return NewReadDataset(s3Factory)
+	return NewReadDataset(dataset, s3Factory)
 }
 
 // isMetricsSnapshot checks if a snapshot contains metrics data

--- a/quarry/lode/dataset_test.go
+++ b/quarry/lode/dataset_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewReadDatasetFS(t *testing.T) {
 	dir := t.TempDir()
-	ds, err := NewReadDatasetFS(dir)
+	ds, err := NewReadDatasetFS("quarry", dir)
 	if err != nil {
 		t.Fatalf("NewReadDatasetFS failed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestNewReadDataset_WriteReadRoundTrip(t *testing.T) {
 	}
 
 	// Read via Dataset.Read
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}

--- a/quarry/lode/metrics_query_test.go
+++ b/quarry/lode/metrics_query_test.go
@@ -57,7 +57,7 @@ func TestQueryLatestMetrics_WriteAndRead(t *testing.T) {
 	}
 
 	// Read via QueryLatestMetrics
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestQueryLatestMetrics_MultipleRuns(t *testing.T) {
 	}
 
 	// Read without filter — should get latest (run-003)
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestQueryLatestMetrics_FilterByRunID(t *testing.T) {
 	}
 
 	// Filter by specific run-id
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestQueryLatestMetrics_FilterBySource(t *testing.T) {
 		}
 	}
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestQueryLatestMetrics_NoMetrics(t *testing.T) {
 	store := lode.NewMemory()
 	factory := sharedFactory(store)
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -504,7 +504,7 @@ func TestQueryLatestMetrics_RunIDSubstringNoCollision(t *testing.T) {
 		}
 	}
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -564,7 +564,7 @@ func TestQueryLatestMetrics_SourceSubstringNoCollision(t *testing.T) {
 		}
 	}
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestQueryLatestMetrics_RecordLevelFiltering(t *testing.T) {
 		t.Fatalf("WriteMetrics failed: %v", err)
 	}
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}
@@ -665,7 +665,7 @@ func TestQueryLatestMetrics_TsRoundTrip(t *testing.T) {
 		t.Fatalf("WriteMetrics failed: %v", err)
 	}
 
-	ds, err := NewReadDataset(factory)
+	ds, err := NewReadDataset("quarry", factory)
 	if err != nil {
 		t.Fatalf("NewReadDataset failed: %v", err)
 	}

--- a/quarry/lode/sink.go
+++ b/quarry/lode/sink.go
@@ -19,10 +19,13 @@ func DeriveDay(startTime time.Time) string {
 	return startTime.UTC().Format("2006-01-02")
 }
 
+// DefaultDataset is the default Lode dataset name.
+const DefaultDataset = "quarry"
+
 // Config holds Lode sink configuration.
 // All partition keys are required per CONTRACT_LODE.md.
 type Config struct {
-	// Dataset is the Lode dataset ID (fixed to "quarry").
+	// Dataset is the Lode dataset ID (default: "quarry", overridable via --storage-dataset).
 	Dataset string
 	// Source is the partition key for origin system/provider.
 	Source string


### PR DESCRIPTION
## Summary

Adds `--storage-dataset` flag (default: `"quarry"`) to override the Lode dataset ID. The flag name follows the `--storage-*` prefix convention used by `--storage-backend`, `--storage-path`, `--storage-region`, etc.

Closes #94

## Highlights

- `--storage-dataset` flag on `quarry run` wired through `buildPolicy` → `buildStorageSink` → `lode.Config.Dataset`
- `--storage-dataset` flag on `quarry stats metrics` wired through `buildReadDataset` → `NewReadDatasetFS`/`NewReadDatasetS3`
- `--storage-dataset` flag on `quarry inspect run/job/task` (forward-compatible for Lode backing)
- Parameterized `NewReadDataset`, `NewReadDatasetFS`, `NewReadDatasetS3` to accept dataset string
- Exported `lode.DefaultDataset` constant
- Updated CLI_PARITY.json, CONTRACT_CLI, CONTRACT_LODE, and user-facing docs

## Test plan

- [x] `go test ./...` — all packages pass
- [x] CLI parity tests validate new flag against artifact
- [ ] Manual: `quarry run --storage-dataset my-project --storage-backend fs --storage-path ./data ...` writes to `datasets/my-project/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)