### PR TITLE
chore(docs): ✏️ fix missed v0.4.0 version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:justapithecus/quarry@0.4.0
+mise install github:justapithecus/quarry@0.4.1
 ```
 
 ### SDK

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.4.0
+# Support Posture — Quarry v0.4.1
 
-This document defines support expectations for Quarry v0.4.0.
+This document defines support expectations for Quarry v0.4.1.
 
 ---
 
 ## Maturity Level
 
-**v0.4.0 is an early release.** APIs and behaviors may change in subsequent
+**v0.4.1 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.4.0._
+_No known issues in v0.4.1._
 
 ---
 
@@ -123,12 +123,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.4.0 (commit: ...)
+# 0.4.1 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.4.0 is provided "as is" without warranty of any kind.
+Quarry v0.4.1 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,10 +13,11 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.4.0)
-- Latest release: v0.4.0 (see CHANGELOG.md).
+## Current Status (as of v0.4.1)
+- Latest release: v0.4.1 (see CHANGELOG.md).
 - Phases 0–5 complete. Phase 6 (dogfooding) in progress.
-- v0.4.0 adds `ctx.storage.put()` for sidecar file uploads via Lode Store.
+- v0.4.1 adds `--config` for YAML project-level defaults and config package hardening.
+- v0.4.0 added `ctx.storage.put()` for sidecar file uploads via Lode Store.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes remaining `v0.4.0` → `v0.4.1` version references in README.md, SUPPORT.md, and IMPLEMENTATION_PLAN.md that were missed in the v0.4.1 release prep (#105).

## Highlights

- **README.md**: `mise install` version bump to `0.4.1`
- **SUPPORT.md**: all 6 version references updated
- **IMPLEMENTATION_PLAN.md**: current status section updated, historical v0.4.0 entry preserved

## Test plan

- [ ] `git grep '0\.4\.0'` returns no hits outside CHANGELOG.md, lode-upgrade.md, go.sum, pnpm-lock.yaml
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)