### PR TITLE
chore(release): 🔖 prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ _No unreleased changes._
 
 ---
 
+## [0.5.0] - 2026-02-07
+
+### Added
+
+- **Adapter**: Redis pub/sub adapter — publishes `RunCompletedEvent` as JSON to a configurable Redis channel after run completion (#107)
+- **Adapter**: `--adapter-channel` CLI flag for Redis pub/sub channel name (default: `quarry:run_completed`) (#107)
+- **Adapter**: Redis adapter config in YAML: `adapter.channel` field (#107)
+- **Adapter**: Webhook adapter — HTTP POST with retries, custom headers, timeout (#103)
+- **Adapter**: `Adapter` interface and `RunCompletedEvent` type in `quarry/adapter/` (#103)
+- **Adapter**: CLI flags: `--adapter`, `--adapter-url`, `--adapter-header`, `--adapter-timeout`, `--adapter-retries` (#103)
+- **Contracts**: CONTRACT_INTEGRATION.md updated with runtime adapter reference, Redis and webhook (#103, #107)
+- **Contracts**: CONTRACT_CLI.md updated with adapter flags including `--adapter-channel` (#103, #107)
+- **Docs**: Integration guide updated with webhook and Redis adapter examples (#103, #107)
+- **Docs**: Configuration guide updated with adapter section (#107)
+
+### Changed
+
+- **Docs**: CLI_PARITY.json updated with adapter flags and validation (#103, #107)
+
+---
+
 ## [0.4.1] - 2026-02-07
 
 ### Added
@@ -250,6 +271,7 @@ _No unreleased changes._
 
 ---
 
+[0.5.0]: https://github.com/justapithecus/quarry/releases/tag/v0.5.0
 [0.4.1]: https://github.com/justapithecus/quarry/releases/tag/v0.4.1
 [0.4.0]: https://github.com/justapithecus/quarry/releases/tag/v0.4.0
 [0.3.5]: https://github.com/justapithecus/quarry/releases/tag/v0.3.5

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.4.1.
+User-facing guide for Quarry v0.5.0.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,14 +26,14 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:justapithecus/quarry@0.4.1
+mise install github:justapithecus/quarry@0.5.0
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:justapithecus/quarry" = "0.4.1"
+"github:justapithecus/quarry" = "0.5.0"
 ```
 
 ### SDK
@@ -259,9 +259,10 @@ CLI flags always override config file values.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--adapter <type>` | | Adapter type (`webhook`) |
+| `--adapter <type>` | | Adapter type (`webhook`, `redis`) |
 | `--adapter-url <url>` | | Endpoint URL (required when `--adapter` set) |
-| `--adapter-header <key=value>` | | Custom HTTP header (repeatable) |
+| `--adapter-header <key=value>` | | Custom HTTP header (repeatable, webhook only) |
+| `--adapter-channel <name>` | `quarry:run_completed` | Pub/sub channel name (redis only) |
 | `--adapter-timeout <duration>` | `10s` | Notification timeout |
 | `--adapter-retries <n>` | `3` | Retry attempts |
 
@@ -394,7 +395,7 @@ task build
 
 ---
 
-## Known Limitations (v0.4.1)
+## Known Limitations (v0.5.0)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -402,7 +403,7 @@ task build
 4. **S3 is experimental**: S3 and S3-compatible providers (R2, MinIO) are supported but experimental; no transactional guarantees across writes
 5. **No job scheduling**: Quarry is an execution runtime, not a scheduler
 6. **Puppeteer required**: All scripts run in a browser context
-7. **Event bus adapters**: Only webhook adapter is available. Temporal, NATS, and SNS adapters are planned. For v0.4.x, use shell wrappers or external notification scripts for downstream triggers. See `docs/guides/integration.md`.
+7. **Event bus adapters**: Webhook and Redis pub/sub adapters are available. Temporal, NATS, and SNS adapters are planned. See `docs/guides/integration.md`.
 
 ---
 
@@ -465,8 +466,9 @@ export AWS_SECRET_ACCESS_KEY=<secret-key>
 Quarry is an extraction runtime, not a full pipeline. For triggering downstream
 processing after runs complete, see [docs/guides/integration.md](docs/guides/integration.md).
 
-**Built-in adapter** (v0.5.0+): `--adapter webhook` sends an HTTP POST after
-each run completes. See adapter flags above.
+**Built-in adapters** (v0.5.0+): `--adapter webhook` sends an HTTP POST, and
+`--adapter redis` publishes to a Redis pub/sub channel after each run completes.
+See adapter flags above.
 
 **Fallback pattern**: Polling-based triggers with idempotent checkpoints.
 
@@ -476,7 +478,7 @@ each run completes. See adapter flags above.
 
 ```bash
 quarry version
-# 0.4.1 (commit: ...)
+# 0.5.0 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -485,6 +487,6 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.4.1` |
+| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.5.0` |
 | SDK | JSR | `npx jsr add @justapithecus/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @justapithecus/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:justapithecus/quarry@0.4.1
+mise install github:justapithecus/quarry@0.5.0
 ```
 
 ### SDK

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.4.1
+# Support Posture — Quarry v0.5.0
 
-This document defines support expectations for Quarry v0.4.1.
+This document defines support expectations for Quarry v0.5.0.
 
 ---
 
 ## Maturity Level
 
-**v0.4.1 is an early release.** APIs and behaviors may change in subsequent
+**v0.5.0 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.4.1._
+_No known issues in v0.5.0._
 
 ---
 
@@ -130,5 +130,5 @@ quarry version
 
 ## No Warranty
 
-Quarry v0.4.1 is provided "as is" without warranty of any kind.
+Quarry v0.5.0 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,10 +13,11 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.4.1)
-- Latest release: v0.4.1 (see CHANGELOG.md).
+## Current Status (as of v0.5.0)
+- Latest release: v0.5.0 (see CHANGELOG.md).
 - Phases 0–5 complete. Phase 6 (dogfooding) in progress.
-- v0.4.1 adds `--config` for YAML project-level defaults and config package hardening.
+- v0.5.0 adds webhook and Redis pub/sub event-bus adapters for downstream notifications.
+- v0.4.1 added `--config` for YAML project-level defaults and config package hardening.
 - v0.4.0 added `ctx.storage.put()` for sidecar file uploads via Lode Store.
 
 ---
@@ -342,7 +343,8 @@ to poll Lode or wire external plumbing.
 ### Deliverables
 - `Adapter` interface and `RunCompletedEvent` type (`quarry/adapter/`)
 - Webhook adapter: HTTP POST with retries, custom headers, timeout (`quarry/adapter/webhook/`)
-- CLI flags: `--adapter`, `--adapter-url`, `--adapter-header`, `--adapter-timeout`, `--adapter-retries`
+- Redis pub/sub adapter: PUBLISH with retries, configurable channel (`quarry/adapter/redis/`)
+- CLI flags: `--adapter`, `--adapter-url`, `--adapter-header`, `--adapter-channel`, `--adapter-timeout`, `--adapter-retries`
 - Hook in `runAction()` after metrics persist (best-effort, does not fail run)
 - Contract and guide updates
 
@@ -355,6 +357,15 @@ to poll Lode or wire external plumbing.
 - [x] CONTRACT_CLI.md updated with adapter flags
 - [x] Integration guide updated with webhook example
 - [x] CLI_PARITY.json updated
+
+### Redis Pub/Sub Adapter (v0.5.0)
+- [x] Redis adapter implementation (`quarry/adapter/redis/redis.go`)
+- [x] Redis adapter tests with miniredis (`quarry/adapter/redis/redis_test.go`)
+- [x] `--adapter-channel` CLI flag
+- [x] Config YAML `channel` field in adapter stanza
+- [x] CLI wiring in `run.go` (import, flag, parse, build)
+- [x] CLI_PARITY.json updated
+- [x] CONTRACT_INTEGRATION.md and CONTRACT_CLI.md updated
 
 ### Future adapters (separate PRs)
 - Temporal
@@ -459,6 +470,7 @@ Phase 2 is deferred until Phase 1 is validated in production.
 ## Post-v0.5.0 — Additional Event Bus Adapters (Staggered)
 
 Order of support:
+- ~~Redis Pub/Sub~~ (shipped in v0.5.0)
 - Temporal.io
 - NATS
 - SNS/SQS

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -98,6 +98,19 @@ Buffered policy requires at least one of `--buffer-events` or `--buffer-bytes` t
 
 See `docs/guides/proxy.md` for pool configuration format and selection behavior.
 
+### Adapter (Event-Bus Notification)
+
+| Flag | Type | Default | Purpose |
+|------|------|---------|---------|
+| `--adapter` | `webhook`, `redis` | | Adapter type |
+| `--adapter-url` | string | | Endpoint URL (required when `--adapter` set) |
+| `--adapter-header` | string (repeatable) | | Custom header as `key=value` (webhook only) |
+| `--adapter-channel` | string | `quarry:run_completed` | Pub/sub channel name (redis only) |
+| `--adapter-timeout` | duration | `10s` (webhook) / `5s` (redis) | Per-request/publish timeout |
+| `--adapter-retries` | int | `3` | Retry attempts |
+
+See `docs/guides/integration.md` for adapter usage patterns.
+
 ### Output
 
 | Flag | Type | Default | Purpose |
@@ -220,6 +233,14 @@ proxies:
 proxy:
   pool: iproyal_nyc
   strategy: round_robin
+
+adapter:
+  type: webhook
+  url: https://hooks.example.com/quarry
+  headers:
+    Authorization: Bearer ${WEBHOOK_TOKEN}
+  timeout: 10s
+  retries: 3
 ```
 
 ### Environment Variable Expansion

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -141,6 +141,48 @@ run exits with its normal outcome code.
 | `--adapter-retries` | `3` | Retry attempts with exponential backoff |
 | `--adapter-header` | | Custom header (repeatable, `key=value` format) |
 
+### Redis Pub/Sub Adapter (v0.5.0+)
+
+Quarry ships a built-in Redis pub/sub adapter that publishes a JSON event
+to a configurable Redis channel after each run completes.
+
+```bash
+quarry run \
+  --script ./script.ts \
+  --run-id run-001 \
+  --source my-source \
+  --storage-backend fs \
+  --storage-path ./data \
+  --adapter redis \
+  --adapter-url redis://localhost:6379/0 \
+  --adapter-channel quarry:run_completed
+```
+
+The adapter publishes after storage commit and metrics persist. If the
+publish fails (after retries), the warning is logged to stderr but the
+run exits with its normal outcome code.
+
+#### Redis Adapter Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--adapter-channel` | `quarry:run_completed` | Pub/sub channel name |
+| `--adapter-timeout` | `5s` | Per-publish timeout |
+| `--adapter-retries` | `3` | Retry attempts with exponential backoff |
+
+The `--adapter-header` flag is ignored for the Redis adapter (with a warning).
+
+#### YAML Config Example
+
+```yaml
+adapter:
+  type: redis
+  url: redis://localhost:6379/0
+  channel: quarry:run_completed
+  timeout: 5s
+  retries: 3
+```
+
 ### Interim Pattern (v0.4.x)
 
 Before v0.5.0, use a shell wrapper to trigger downstream notifications:

--- a/quarry/adapter/redis/redis_test.go
+++ b/quarry/adapter/redis/redis_test.go
@@ -13,7 +13,7 @@ import (
 
 func testEvent() *adapter.RunCompletedEvent {
 	return &adapter.RunCompletedEvent{
-		ContractVersion: "0.4.1",
+		ContractVersion: "0.5.0",
 		EventType:       "run_completed",
 		RunID:           "run-001",
 		Source:          "test-source",

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.4.1
+// Quarry Executor Bundle v0.5.0
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -1744,7 +1744,7 @@ import { dirname, resolve as resolve2 } from "node:path";
 
 // ../sdk/dist/index.mjs
 import { randomUUID } from "node:crypto";
-var CONTRACT_VERSION = "0.4.1";
+var CONTRACT_VERSION = "0.5.0";
 var TerminalEventError = class extends Error {
   constructor() {
     super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.4.1"
+const Version = "0.5.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.4.1' as const
+export const CONTRACT_VERSION = '0.5.0' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.4.1",
+    "contract_version": "0.5.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Prepare v0.5.0 release with lockstep version bump (0.4.1 → 0.5.0), documentation updates for the new webhook and Redis pub/sub event-bus adapters, and rebuilt SDK/executor bundles.

## Highlights

- **Version bump**: `quarry/types/version.go`, `sdk/package.json`, `sdk/src/types/events.ts`, golden fixtures all at `0.5.0`
- **CHANGELOG**: v0.5.0 entry covering webhook (#103) and Redis pub/sub (#107) adapter additions
- **Integration guide**: Added Redis adapter section with CLI and YAML examples
- **Configuration guide**: Added adapter flags section (webhook + redis)
- **PUBLIC_API.md**: Updated adapter flags table (added `--adapter-channel`), known limitations updated
- **IMPLEMENTATION_PLAN.md**: Redis adapter milestones checked off, current status updated to v0.5.0
- **SUPPORT.md, README.md**: Version references updated
- **Executor bundle**: Rebuilt at v0.5.0

## Test plan

- [x] `go test ./...` — all 18 packages pass
- [x] `go build ./...` — compiles clean
- [x] `pnpm -C sdk run test` — 172 tests pass (including golden fixtures)
- [x] `task lint` — no lint errors
- [x] `task version:lockstep` — ✅ Go 0.5.0 == SDK 0.5.0
- [x] `task cli:parity` — 7 parity tests pass
- [x] `git grep '0\.4\.1'` sweep — no stale references outside historical entries
- [ ] CI passes all 7 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)