### PR TITLE
fix(ci): 🐛 build SDK before publishing to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,11 @@ jobs:
             exit 1
           fi
           echo "✅ pnpm version matches pin"
+      - name: "📦 Install dependencies"
+        run: pnpm install
+      - name: "🏗️ Build SDK"
+        working-directory: sdk
+        run: pnpm run build
       - name: "🔍 Publish Diagnostics"
         working-directory: sdk
         run: |


### PR DESCRIPTION
## Summary

The `publish_ghpr` job in the release workflow ran `pnpm publish` without
installing dependencies or building the SDK first, so the `dist/` directory
was missing from the published tarball.

## Highlights

- Add `pnpm install` step to `publish_ghpr` job
- Add `pnpm run build` step (runs `tsdown`) before publish diagnostics
- Ensures `dist/` exists when `pnpm publish` creates the tarball

## Test plan

- [ ] CI passes on this PR
- [ ] Verify with `release-dry-run` workflow if available

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)