### PR TITLE
refactor(lode): ♻️ decouple lode from cli/reader dependency

### DIFF
--- a/quarry/cli/cmd/stats.go
+++ b/quarry/cli/cmd/stats.go
@@ -177,7 +177,7 @@ func statsMetricsAction(c *cli.Context) error {
 			return fmt.Errorf("failed to read metrics from Lode: %w", err)
 		}
 
-		parsed, err := lode.ParseMetricsRecord(record)
+		parsed, err := reader.ParseMetricsRecord(record)
 		if err != nil {
 			return fmt.Errorf("failed to parse metrics record: %w", err)
 		}

--- a/quarry/cli/reader/parse.go
+++ b/quarry/cli/reader/parse.go
@@ -1,0 +1,109 @@
+package reader
+
+import "errors"
+
+// ParseMetricsRecord converts a Lode record (map[string]any) to a MetricsSnapshot.
+// Handles both int64 (direct writes) and float64 (JSON round-trips) for numeric fields.
+func ParseMetricsRecord(record map[string]any) (*MetricsSnapshot, error) {
+	if record == nil {
+		return nil, errors.New("nil record")
+	}
+
+	snap := &MetricsSnapshot{
+		Ts: toString(record["ts"]),
+
+		// Run lifecycle
+		RunsStarted:   toInt64(record["runs_started_total"]),
+		RunsCompleted: toInt64(record["runs_completed_total"]),
+		RunsFailed:    toInt64(record["runs_failed_total"]),
+		RunsCrashed:   toInt64(record["runs_crashed_total"]),
+
+		// Ingestion
+		EventsReceived:  toInt64(record["events_received_total"]),
+		EventsPersisted: toInt64(record["events_persisted_total"]),
+		EventsDropped:   toInt64(record["events_dropped_total"]),
+
+		// Executor
+		ExecutorLaunchSuccess: toInt64(record["executor_launch_success_total"]),
+		ExecutorLaunchFailure: toInt64(record["executor_launch_failure_total"]),
+		ExecutorCrash:         toInt64(record["executor_crash_total"]),
+		IPCDecodeErrors:       toInt64(record["ipc_decode_errors_total"]),
+
+		// Lode / Storage
+		LodeWriteSuccess: toInt64(record["lode_write_success_total"]),
+		LodeWriteFailure: toInt64(record["lode_write_failure_total"]),
+		LodeWriteRetry:   toInt64(record["lode_write_retry_total"]),
+
+		// Dimensions
+		Policy:         toString(record["policy"]),
+		Executor:       toString(record["executor"]),
+		StorageBackend: toString(record["storage_backend"]),
+		RunID:          toString(record["run_id"]),
+		JobID:          toString(record["job_id"]),
+	}
+
+	// Parse dropped_by_type if present
+	if dbt, ok := record["dropped_by_type"]; ok && dbt != nil {
+		snap.DroppedByType = parseDroppedByType(dbt)
+	}
+
+	// Validate contract-required fields per CONTRACT_CLI.md.
+	// The write path always populates these; missing values indicate
+	// data corruption or a malformed record.
+	if snap.Ts == "" {
+		return nil, errors.New("metrics record missing required field: ts")
+	}
+	if snap.RunID == "" {
+		return nil, errors.New("metrics record missing required field: run_id")
+	}
+	if snap.Policy == "" {
+		return nil, errors.New("metrics record missing required field: policy")
+	}
+	if snap.Executor == "" {
+		return nil, errors.New("metrics record missing required field: executor")
+	}
+	if snap.StorageBackend == "" {
+		return nil, errors.New("metrics record missing required field: storage_backend")
+	}
+
+	return snap, nil
+}
+
+// toInt64 converts a value to int64, handling float64 from JSON and int64 from direct writes.
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	default:
+		return 0
+	}
+}
+
+// toString converts a value to string, returning empty string for nil/non-string.
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// parseDroppedByType converts dropped_by_type from Lode record format.
+// Handles both map[string]int64 (direct) and map[string]any (JSON round-trip).
+func parseDroppedByType(v any) map[string]int64 {
+	switch m := v.(type) {
+	case map[string]int64:
+		return m
+	case map[string]any:
+		result := make(map[string]int64, len(m))
+		for k, val := range m {
+			result[k] = toInt64(val)
+		}
+		return result
+	default:
+		return nil
+	}
+}

--- a/quarry/cli/reader/parse_test.go
+++ b/quarry/cli/reader/parse_test.go
@@ -1,0 +1,168 @@
+package reader
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMetricsRecord(t *testing.T) {
+	// Simulate a JSON-round-tripped record (float64 values)
+	record := map[string]any{
+		"record_kind":                   "metrics",
+		"ts":                            "2026-02-03T15:00:00Z",
+		"runs_started_total":            float64(5),
+		"runs_completed_total":          float64(4),
+		"runs_failed_total":             float64(1),
+		"runs_crashed_total":            float64(0),
+		"events_received_total":         float64(100),
+		"events_persisted_total":        float64(98),
+		"events_dropped_total":          float64(2),
+		"executor_launch_success_total": float64(5),
+		"executor_launch_failure_total": float64(0),
+		"executor_crash_total":          float64(0),
+		"ipc_decode_errors_total":       float64(1),
+		"lode_write_success_total":      float64(50),
+		"lode_write_failure_total":      float64(0),
+		"lode_write_retry_total":        float64(3),
+		"policy":                        "buffered",
+		"executor":                      "my-executor.js",
+		"storage_backend":               "s3",
+		"run_id":                        "run-abc",
+		"job_id":                        "job-def",
+		"dropped_by_type":               map[string]any{"log": float64(2)},
+	}
+
+	parsed, err := ParseMetricsRecord(record)
+	if err != nil {
+		t.Fatalf("ParseMetricsRecord failed: %v", err)
+	}
+
+	if parsed.Ts != "2026-02-03T15:00:00Z" {
+		t.Errorf("Ts = %q, want %q", parsed.Ts, "2026-02-03T15:00:00Z")
+	}
+	if parsed.RunsStarted != 5 {
+		t.Errorf("RunsStarted = %d, want 5", parsed.RunsStarted)
+	}
+	if parsed.RunsCompleted != 4 {
+		t.Errorf("RunsCompleted = %d, want 4", parsed.RunsCompleted)
+	}
+	if parsed.RunsFailed != 1 {
+		t.Errorf("RunsFailed = %d, want 1", parsed.RunsFailed)
+	}
+	if parsed.EventsReceived != 100 {
+		t.Errorf("EventsReceived = %d, want 100", parsed.EventsReceived)
+	}
+	if parsed.EventsPersisted != 98 {
+		t.Errorf("EventsPersisted = %d, want 98", parsed.EventsPersisted)
+	}
+	if parsed.EventsDropped != 2 {
+		t.Errorf("EventsDropped = %d, want 2", parsed.EventsDropped)
+	}
+	if parsed.IPCDecodeErrors != 1 {
+		t.Errorf("IPCDecodeErrors = %d, want 1", parsed.IPCDecodeErrors)
+	}
+	if parsed.LodeWriteSuccess != 50 {
+		t.Errorf("LodeWriteSuccess = %d, want 50", parsed.LodeWriteSuccess)
+	}
+	if parsed.LodeWriteRetry != 3 {
+		t.Errorf("LodeWriteRetry = %d, want 3", parsed.LodeWriteRetry)
+	}
+	if parsed.Policy != "buffered" {
+		t.Errorf("Policy = %q, want %q", parsed.Policy, "buffered")
+	}
+	if parsed.Executor != "my-executor.js" {
+		t.Errorf("Executor = %q, want %q", parsed.Executor, "my-executor.js")
+	}
+	if parsed.StorageBackend != "s3" {
+		t.Errorf("StorageBackend = %q, want %q", parsed.StorageBackend, "s3")
+	}
+	if parsed.RunID != "run-abc" {
+		t.Errorf("RunID = %q, want %q", parsed.RunID, "run-abc")
+	}
+	if parsed.JobID != "job-def" {
+		t.Errorf("JobID = %q, want %q", parsed.JobID, "job-def")
+	}
+	if parsed.DroppedByType == nil {
+		t.Fatal("DroppedByType should not be nil")
+	}
+	if parsed.DroppedByType["log"] != 2 {
+		t.Errorf("DroppedByType[log] = %d, want 2", parsed.DroppedByType["log"])
+	}
+}
+
+func TestParseMetricsRecord_NilRecord(t *testing.T) {
+	_, err := ParseMetricsRecord(nil)
+	if err == nil {
+		t.Error("expected error for nil record")
+	}
+}
+
+func TestParseMetricsRecord_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		record map[string]any
+		errMsg string
+	}{
+		{
+			name:   "missing ts",
+			record: map[string]any{"record_kind": "metrics", "run_id": "run-1", "policy": "strict", "executor": "e.js", "storage_backend": "fs"},
+			errMsg: "ts",
+		},
+		{
+			name:   "missing run_id",
+			record: map[string]any{"record_kind": "metrics", "ts": "2026-02-03T15:00:00Z", "policy": "strict", "executor": "e.js", "storage_backend": "fs"},
+			errMsg: "run_id",
+		},
+		{
+			name:   "missing policy",
+			record: map[string]any{"record_kind": "metrics", "ts": "2026-02-03T15:00:00Z", "run_id": "run-1", "executor": "e.js", "storage_backend": "fs"},
+			errMsg: "policy",
+		},
+		{
+			name:   "missing executor",
+			record: map[string]any{"record_kind": "metrics", "ts": "2026-02-03T15:00:00Z", "run_id": "run-1", "policy": "strict", "storage_backend": "fs"},
+			errMsg: "executor",
+		},
+		{
+			name:   "missing storage_backend",
+			record: map[string]any{"record_kind": "metrics", "ts": "2026-02-03T15:00:00Z", "run_id": "run-1", "policy": "strict", "executor": "e.js"},
+			errMsg: "storage_backend",
+		},
+		{
+			name:   "all required missing",
+			record: map[string]any{"record_kind": "metrics"},
+			errMsg: "ts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseMetricsRecord(tt.record)
+			if err == nil {
+				t.Fatal("expected error for missing required field, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestParseMetricsRecord_Ts(t *testing.T) {
+	record := map[string]any{
+		"record_kind":     "metrics",
+		"ts":              "2026-02-03T15:30:00Z",
+		"run_id":          "run-1",
+		"policy":          "strict",
+		"executor":        "executor.js",
+		"storage_backend": "fs",
+	}
+
+	parsed, err := ParseMetricsRecord(record)
+	if err != nil {
+		t.Fatalf("ParseMetricsRecord failed: %v", err)
+	}
+	if parsed.Ts != "2026-02-03T15:30:00Z" {
+		t.Errorf("Ts = %q, want %q", parsed.Ts, "2026-02-03T15:30:00Z")
+	}
+}

--- a/quarry/lode/metrics_query.go
+++ b/quarry/lode/metrics_query.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/justapithecus/lode/lode"
-
-	"github.com/justapithecus/quarry/cli/reader"
 )
 
 // ErrNoMetricsFound is returned when no metrics records exist in the dataset.
@@ -66,108 +64,10 @@ func QueryLatestMetrics(ctx context.Context, ds lode.Dataset, runID, source stri
 	return nil, ErrNoMetricsFound
 }
 
-// ParseMetricsRecord converts a Lode record (map[string]any) to a reader.MetricsSnapshot.
-// Handles both int64 (direct writes) and float64 (JSON round-trips) for numeric fields.
-func ParseMetricsRecord(record map[string]any) (*reader.MetricsSnapshot, error) {
-	if record == nil {
-		return nil, errors.New("nil record")
-	}
-
-	snap := &reader.MetricsSnapshot{
-		Ts: toString(record["ts"]),
-
-		// Run lifecycle
-		RunsStarted:   toInt64(record["runs_started_total"]),
-		RunsCompleted: toInt64(record["runs_completed_total"]),
-		RunsFailed:    toInt64(record["runs_failed_total"]),
-		RunsCrashed:   toInt64(record["runs_crashed_total"]),
-
-		// Ingestion
-		EventsReceived:  toInt64(record["events_received_total"]),
-		EventsPersisted: toInt64(record["events_persisted_total"]),
-		EventsDropped:   toInt64(record["events_dropped_total"]),
-
-		// Executor
-		ExecutorLaunchSuccess: toInt64(record["executor_launch_success_total"]),
-		ExecutorLaunchFailure: toInt64(record["executor_launch_failure_total"]),
-		ExecutorCrash:         toInt64(record["executor_crash_total"]),
-		IPCDecodeErrors:       toInt64(record["ipc_decode_errors_total"]),
-
-		// Lode / Storage
-		LodeWriteSuccess: toInt64(record["lode_write_success_total"]),
-		LodeWriteFailure: toInt64(record["lode_write_failure_total"]),
-		LodeWriteRetry:   toInt64(record["lode_write_retry_total"]),
-
-		// Dimensions
-		Policy:         toString(record["policy"]),
-		Executor:       toString(record["executor"]),
-		StorageBackend: toString(record["storage_backend"]),
-		RunID:          toString(record["run_id"]),
-		JobID:          toString(record["job_id"]),
-	}
-
-	// Parse dropped_by_type if present
-	if dbt, ok := record["dropped_by_type"]; ok && dbt != nil {
-		snap.DroppedByType = parseDroppedByType(dbt)
-	}
-
-	// Validate contract-required fields per CONTRACT_CLI.md.
-	// The write path always populates these; missing values indicate
-	// data corruption or a malformed record.
-	if snap.Ts == "" {
-		return nil, errors.New("metrics record missing required field: ts")
-	}
-	if snap.RunID == "" {
-		return nil, errors.New("metrics record missing required field: run_id")
-	}
-	if snap.Policy == "" {
-		return nil, errors.New("metrics record missing required field: policy")
-	}
-	if snap.Executor == "" {
-		return nil, errors.New("metrics record missing required field: executor")
-	}
-	if snap.StorageBackend == "" {
-		return nil, errors.New("metrics record missing required field: storage_backend")
-	}
-
-	return snap, nil
-}
-
-// toInt64 converts a value to int64, handling float64 from JSON and int64 from direct writes.
-func toInt64(v any) int64 {
-	switch n := v.(type) {
-	case int64:
-		return n
-	case float64:
-		return int64(n)
-	case int:
-		return int64(n)
-	default:
-		return 0
-	}
-}
-
 // toString converts a value to string, returning empty string for nil/non-string.
 func toString(v any) string {
 	if s, ok := v.(string); ok {
 		return s
 	}
 	return ""
-}
-
-// parseDroppedByType converts dropped_by_type from Lode record format.
-// Handles both map[string]int64 (direct) and map[string]any (JSON round-trip).
-func parseDroppedByType(v any) map[string]int64 {
-	switch m := v.(type) {
-	case map[string]int64:
-		return m
-	case map[string]any:
-		result := make(map[string]int64, len(m))
-		for k, val := range m {
-			result[k] = toInt64(val)
-		}
-		return result
-	default:
-		return nil
-	}
 }


### PR DESCRIPTION
## Summary

Move `ParseMetricsRecord` and its conversion helpers from `lode/` into `cli/reader/`, eliminating the layering violation where the storage package imported a CLI presentation package. This unblocks the future `core/cli/temporal` module split — `lode/` must live on the core side, but `cli/reader` is definitionally CLI-side.

## Highlights

- **New `cli/reader/parse.go`** — `ParseMetricsRecord` + `toInt64`, `toString`, `parseDroppedByType` helpers, co-located with the `MetricsSnapshot` type they produce
- **New `cli/reader/parse_test.go`** — 4 unit tests moved from `lode/` (float64 round-trip, nil record, missing required fields, ts parsing)
- **Trimmed `lode/metrics_query.go`** — removed `ParseMetricsRecord`, `toInt64`, `parseDroppedByType`, and the `cli/reader` import; kept `toString` (used by `QueryLatestMetrics`)
- **Rewrote `lode/` round-trip tests** — 7 tests now assert on raw `map[string]any` fields with a test-local `toInt64` helper, avoiding any `cli/reader` import
- **Updated `cli/cmd/stats.go`** — single call-site change: `lode.ParseMetricsRecord` → `reader.ParseMetricsRecord`

## Test plan

- [x] `go build ./...` — no import cycles, no missing symbols
- [x] `go test ./lode/...` — round-trip tests pass with raw map assertions
- [x] `go test ./cli/reader/...` — ParseMetricsRecord unit tests pass
- [x] `go test ./cli/cmd/...` — stats command compiles and tests pass
- [x] `task lint` — 0 issues
- [x] `grep -r "cli/" quarry/lode/*.go` — empty (no CLI imports in lode/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)