### PR TITLE
docs(adapter): 📝 document Temporal orchestration integration and module split

### DIFF
--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -37,6 +37,7 @@ User-facing guides (informational).
 - `guides/configuration.md` — consolidated configuration reference (flags, env vars, config files)
 - `guides/proxy.md` — user-facing proxy guide
 - `guides/integration.md` — downstream ETL trigger patterns (event-bus, polling)
+- `guides/temporal.md` — Temporal orchestration integration guide
 
 ### docs/contracts/
 

--- a/docs/contracts/CONTRACT_INTEGRATION.md
+++ b/docs/contracts/CONTRACT_INTEGRATION.md
@@ -1,7 +1,7 @@
-# Quarry Event-Bus Integration Contract
+# Quarry Integration Contract
 
-This document defines the **event-bus adapter boundary** and the **selection
-and delivery semantics** used by the Quarry runtime.
+This document defines the **integration boundary** for downstream notification
+adapters and orchestration integrations used by the Quarry runtime.
 
 This is a contract document. Implementations must conform.
 
@@ -9,6 +9,7 @@ This is a contract document. Implementations must conform.
 
 ## Scope
 
+- Defines the distinction between notification adapters and orchestration integrations.
 - Defines the adapter boundary and ownership.
 - Defines CLI/config selection rules.
 - Defines delivery semantics and required observability.
@@ -17,6 +18,29 @@ Non-goals:
 - Does not define executor behavior.
 - Does not define user script behavior.
 - Does not define provider-specific configuration details.
+- Does not define Temporal workflow semantics (see `guides/temporal.md`).
+
+---
+
+## Integration Paradigms
+
+Quarry supports two distinct integration paradigms:
+
+| Paradigm | Relationship to Runtime | Direction | Examples |
+|----------|------------------------|-----------|----------|
+| Notification Adapter | Invoked **by** runtime after a run | Runtime → External | Webhook, Redis, NATS, SNS |
+| Orchestration Integration | **Wraps** the runtime as embedded activity | External → Runtime | Temporal |
+
+**Notification adapters** are in-process modules that fire after a run
+completes. They implement the `Adapter` interface, are selected via
+`--adapter` flags, and follow best-effort delivery semantics. The runtime
+owns their lifecycle.
+
+**Orchestration integrations** embed the runtime as a unit of work within
+an external orchestrator. The orchestrator owns scheduling, retries, and
+delivery guarantees. Orchestration integrations do NOT implement the
+`Adapter` interface and are NOT selected via `--adapter` flags — they
+are separate binaries that depend on the runtime as a library.
 
 ---
 
@@ -29,15 +53,18 @@ Non-goals:
   but do not fail the run. Run data is already persisted before the
   adapter is invoked.
 
-### Runtime Adapters (v0.5.0+)
+### Notification Adapters (v0.5.0+)
 
 | Adapter | Package | Status |
 |---------|---------|--------|
 | Webhook (HTTP POST) | `quarry/adapter/webhook` | Available |
 | Redis (Pub/Sub) | `quarry/adapter/redis` | Available |
-| Temporal | — | Planned |
 | NATS | — | Planned |
 | SNS | — | Planned |
+
+> Temporal is an orchestration integration, not a notification adapter.
+> See [Orchestration Integration Semantics](#orchestration-integration-semantics)
+> and `guides/temporal.md`.
 
 ---
 
@@ -125,6 +152,60 @@ Adapter publish is the last step before CLI output and exit.
 
 - Credentials must never be emitted in events, logs, or CLI output.
 - Any adapter-specific secrets must be redacted at the boundary.
+
+---
+
+## Orchestration Integration Semantics
+
+This section defines normative requirements for orchestration integrations
+that embed the Quarry runtime as a unit of work.
+
+### Activity Boundary
+
+The orchestrator invokes `runtime.NewRunOrchestrator(config).Execute(ctx)`
+as an atomic unit of work. The runtime owns everything inside this boundary
+(executor lifecycle, IPC, policy, Lode persistence). The orchestrator owns
+everything outside (scheduling, retries, fan-out, notification).
+
+### Outcome Mapping
+
+Orchestration integrations must map `OutcomeStatus` (from `types/lineage.go`)
+to orchestrator-native error semantics:
+
+| OutcomeStatus | Orchestrator Behavior |
+|---------------|----------------------|
+| `success` | Activity completes normally |
+| `script_error` | Retryable error |
+| `executor_crash` | Retryable error |
+| `policy_failure` | Non-retryable error |
+
+`policy_failure` is non-retryable because it indicates a systemic
+configuration problem that retries cannot resolve.
+
+### Lineage Preservation
+
+The orchestrator must set `RunMeta` fields per `RunMeta.Validate()` rules:
+
+- Each execution gets a unique `run_id`.
+- `attempt` starts at 1 and increments on each retry.
+- `parent_run_id` links retries to the previous execution's `run_id`.
+- `attempt == 1` must have `parent_run_id == nil` (initial run).
+- `attempt > 1` must have `parent_run_id != nil` (retry run).
+
+### Heartbeat Contract
+
+Orchestration integrations should heartbeat at a recommended interval of
+30 seconds. Context cancellation from the orchestrator must trigger:
+
+1. Executor kill (best-effort).
+2. Policy flush (best-effort).
+
+### Data Flow
+
+Only orchestration metadata flows through the orchestrator (~10KB: config
+in, result summary out). Run data (events, artifacts, metrics) stays in
+Lode. This keeps orchestrator payloads small and avoids serialization
+limits.
 
 ---
 

--- a/docs/guides/temporal.md
+++ b/docs/guides/temporal.md
@@ -1,0 +1,274 @@
+# Temporal Integration Guide
+
+This guide describes how Quarry integrates with [Temporal](https://temporal.io)
+as an **orchestration integration**. Temporal wraps the Quarry runtime as
+a Temporal activity — it does not use the `--adapter` notification pathway.
+
+This guide is **non-normative**. The authoritative contract for orchestration
+integration semantics is `docs/contracts/CONTRACT_INTEGRATION.md`.
+
+---
+
+## Overview
+
+| Aspect | Standalone CLI | Temporal Orchestration |
+|--------|---------------|----------------------|
+| Scheduling | cron / CI / shell | Temporal schedules + workflows |
+| Retries | Manual (re-run command) | Workflow-level with lineage |
+| Delivery guarantees | Best-effort (or at-least-once with outbox) | At-least-once (durable execution) |
+| Downstream notification | `--adapter webhook` / `--adapter redis` | Separate workflow activity |
+| Package | `quarry` CLI binary | `quarry-temporal/` worker binary |
+
+---
+
+## Architecture
+
+```
+Temporal Worker (quarry-temporal/)
+  -> Workflow: QuarryExtractionWorkflow
+    -> Activity: RunQuarryExtraction
+      -> runtime.NewRunOrchestrator(config).Execute(ctx)
+        -> [executor -> IPC -> policy -> Lode]
+      <- outcome, run_id, duration
+    <- Workflow decides: retry? notify? fan-out?
+```
+
+The activity is a thin in-process wrapper. It calls `NewRunOrchestrator`
+directly — no subprocess, no CLI parsing, no shell invocation. The Quarry
+runtime runs inside the Temporal worker process.
+
+---
+
+## Activity Wrapper
+
+The activity wrapper is intentionally minimal. It translates between
+Temporal's activity contract and Quarry's `RunOrchestrator` API.
+
+```go
+// Pseudocode — illustrative, not compilable.
+func RunQuarryExtraction(ctx workflow.Context, params ExtractionParams) (*ExtractionResult, error) {
+    activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+        StartToCloseTimeout: 4 * time.Hour,
+        HeartbeatTimeout:    60 * time.Second,
+    })
+
+    var result ExtractionResult
+    err := workflow.ExecuteActivity(activityCtx, runQuarryActivity, params).Get(ctx, &result)
+    return &result, err
+}
+
+func runQuarryActivity(ctx context.Context, params ExtractionParams) (*ExtractionResult, error) {
+    config := &runtime.RunConfig{
+        ExecutorPath: params.ExecutorPath,
+        ScriptPath:   params.ScriptPath,
+        Job:          params.Job,
+        RunMeta: &types.RunMeta{
+            RunID:       params.RunID,
+            JobID:       &params.JobID,
+            ParentRunID: params.ParentRunID,
+            Attempt:     params.Attempt,
+        },
+        // ... policy, proxy, source, category
+    }
+
+    orchestrator, err := runtime.NewRunOrchestrator(config)
+    if err != nil {
+        return nil, temporal.NewNonRetryableApplicationError("invalid config", "CONFIG_ERROR", err)
+    }
+
+    // Heartbeat goroutine — reports liveness to Temporal.
+    done := make(chan struct{})
+    go func() {
+        ticker := time.NewTicker(30 * time.Second)
+        defer ticker.Stop()
+        for {
+            select {
+            case <-ticker.C:
+                activity.RecordHeartbeat(ctx, "running")
+            case <-done:
+                return
+            }
+        }
+    }()
+
+    result, execErr := orchestrator.Execute(ctx)
+    close(done)
+
+    if execErr != nil {
+        return nil, execErr
+    }
+
+    // Map outcome to Temporal error semantics.
+    return mapOutcome(result)
+}
+```
+
+Key design choices:
+
+- **In-process** (Strategy A): the activity calls Go functions directly.
+  No subprocess, no CLI parsing overhead, no serialization boundary.
+- **Heartbeat goroutine**: runs concurrently with `Execute()`. Context
+  cancellation from Temporal propagates through `ctx`, triggering executor
+  kill and best-effort policy flush.
+- **`MaximumAttempts: 1` on the activity**: retries happen at the workflow
+  level so Quarry can record explicit lineage in Lode (each retry gets a
+  new `run_id`, incremented `attempt`, and linked `parent_run_id`).
+
+---
+
+## Lineage Mapping
+
+Quarry's lineage model maps to Temporal concepts:
+
+| Quarry Field | Temporal Equivalent | Who Sets It |
+|-------------|-------------------|-------------|
+| `run_id` | (generated per execution) | Workflow |
+| `job_id` | Workflow ID | Workflow |
+| `attempt` | Workflow retry counter + 1 | Workflow |
+| `parent_run_id` | Previous activity's `run_id` | Workflow |
+
+The workflow generates a new `run_id` for each execution attempt and
+threads `parent_run_id` through from the previous attempt's result.
+This satisfies `RunMeta.Validate()` rules:
+
+- `attempt == 1` → `parent_run_id` is nil (initial run).
+- `attempt > 1` → `parent_run_id` is the previous execution's `run_id`.
+
+Retries are workflow-level (not activity-level) so each Quarry run gets
+its own `run_id` recorded in Lode, preserving full lineage.
+
+---
+
+## Heartbeat and Cancellation
+
+### Recommended Timeouts
+
+| Timeout | Value | Rationale |
+|---------|-------|-----------|
+| `StartToCloseTimeout` | 4 hours | Upper bound for longest extraction |
+| `HeartbeatTimeout` | 60 seconds | Detect stuck activities quickly |
+| `ScheduleToStartTimeout` | 5 minutes | Detect worker unavailability |
+
+### Cancellation Behavior
+
+When Temporal cancels an activity (heartbeat timeout, workflow cancellation,
+or explicit termination):
+
+1. `ctx.Done()` fires inside `RunOrchestrator.Execute()`.
+2. Runtime kills the executor process (best-effort).
+3. Policy flush runs (best-effort) to persist any buffered events.
+4. Activity returns an error; Temporal marks the activity as failed.
+
+The heartbeat goroutine should check `ctx.Err()` to stop cleanly.
+
+---
+
+## Error Mapping
+
+The activity maps `OutcomeStatus` to Temporal error types per
+`CONTRACT_INTEGRATION.md`:
+
+| OutcomeStatus | Temporal Behavior | Implementation |
+|---------------|------------------|----------------|
+| `success` | Activity completes normally | Return result, nil error |
+| `script_error` | Retryable error | Return `temporal.NewApplicationError(...)` |
+| `executor_crash` | Retryable error | Return `temporal.NewApplicationError(...)` |
+| `policy_failure` | Non-retryable error | Return `temporal.NewNonRetryableApplicationError(...)` |
+
+`policy_failure` is non-retryable because it indicates a configuration
+problem (e.g., invalid policy settings) that retries cannot resolve.
+
+---
+
+## Data Flow
+
+Temporal has payload size limits and serialization overhead. Quarry keeps
+orchestrator payloads small:
+
+| What | Where | Size |
+|------|-------|------|
+| Extraction config (script path, job, proxy, run meta) | Temporal activity input | ~1–5 KB |
+| Result summary (outcome, run_id, duration, event count) | Temporal activity output | ~1 KB |
+| Events, artifacts, metrics | Lode (direct write) | Unbounded |
+
+Run data never flows through Temporal. The activity writes directly to
+Lode during execution. Downstream consumers read from Lode, not from
+Temporal's payload store.
+
+---
+
+## Batch Patterns
+
+### Small Batches (<500 runs)
+
+Execute extractions as parallel activities within a single workflow:
+
+```
+Workflow: BatchExtraction
+  -> Activity: RunQuarryExtraction (run 1)
+  -> Activity: RunQuarryExtraction (run 2)
+  -> ...
+  -> Activity: RunQuarryExtraction (run N)
+  <- Aggregate results
+```
+
+### Large Batches (>500 runs)
+
+Use child workflows to avoid Temporal history size limits:
+
+```
+Workflow: LargeBatchExtraction
+  -> ChildWorkflow: BatchChunk (runs 1–500)
+    -> Activity: RunQuarryExtraction (run 1)
+    -> ...
+  -> ChildWorkflow: BatchChunk (runs 501–1000)
+    -> Activity: RunQuarryExtraction (run 501)
+    -> ...
+  <- Aggregate child results
+```
+
+Each child workflow has its own history, avoiding the ~50K event limit
+per workflow execution.
+
+---
+
+## Outbox Pattern and Temporal
+
+| Deployment | Notification Mechanism | Delivery Guarantee |
+|-----------|----------------------|-------------------|
+| Standalone CLI | `--adapter webhook` + outbox | Best-effort (or at-least-once with outbox) |
+| Temporal | Separate workflow activity | At-least-once (durable execution) |
+
+In a Temporal deployment, downstream notification becomes a separate
+activity in the workflow — e.g., a webhook POST or SNS publish activity
+that runs after the extraction activity completes. Temporal's durable
+execution guarantees at-least-once delivery without the outbox pattern.
+
+The outbox pattern (see `docs/IMPLEMENTATION_PLAN.md`) remains relevant
+for standalone CLI deployments where no external orchestrator provides
+delivery guarantees.
+
+---
+
+## Module Structure
+
+The Temporal integration requires a Go module split so `quarry-temporal/`
+can depend on core runtime types without pulling in CLI/TUI dependencies.
+
+| Module | Contains | Depends On |
+|--------|----------|-----------|
+| `quarry-core/` | types, runtime, policy, lode, adapter, proxy, metrics | (standalone) |
+| `quarry-cli/` | CLI commands, TUI, config | `quarry-core/` |
+| `quarry-temporal/` | activity, workflow, worker | `quarry-core/`, `go.temporal.io/sdk` |
+
+See `docs/IMPLEMENTATION_PLAN.md` for the module split roadmap and
+sequencing.
+
+---
+
+## Related Documents
+
+- `docs/contracts/CONTRACT_INTEGRATION.md` — normative orchestration integration semantics
+- `docs/contracts/CONTRACT_RUN.md` — run lifecycle, lineage, and outcome rules
+- `docs/guides/integration.md` — downstream notification patterns (event-bus, polling)
+- `docs/IMPLEMENTATION_PLAN.md` — module split and Temporal roadmap


### PR DESCRIPTION
## Summary

Establish the normative distinction between notification adapters and orchestration integrations. Document Temporal as an orchestration integration (not an adapter) with a detailed guide and roadmap for the Go module split required to support it.

Documentation only — no code changes.

## Highlights

- **CONTRACT_INTEGRATION.md**: New "Integration Paradigms" section with notification vs orchestration taxonomy. New "Orchestration Integration Semantics" section defining activity boundary, outcome mapping, lineage preservation, heartbeat contract, and data flow constraints. Renamed adapter table header, removed Temporal from adapter list.
- **guides/temporal.md** (new): Complete user-facing guide covering architecture, activity wrapper pseudocode, lineage mapping, heartbeat/cancellation, error mapping, data flow, batch patterns, outbox comparison, and module structure.
- **IMPLEMENTATION_PLAN.md**: New "Module Split" section with agreed layout, dependency graph, prerequisites, and sequencing. New "Temporal Orchestration Integration" section with deliverables and milestones. Updated Post-v0.5.0 and outbox sections to reflect Temporal as orchestration (not adapter).
- **ARCH_INDEX.md**: Added `guides/temporal.md` entry.

## Test plan

- [ ] All cross-references resolve (contract ↔ guide ↔ plan ↔ arch index)
- [ ] Outcome mapping matches `types/lineage.go` constants: `success`, `script_error`, `executor_crash`, `policy_failure`
- [ ] RunMeta fields match: `RunID`, `JobID *string`, `ParentRunID *string`, `Attempt int`
- [ ] Existing contract content unchanged (additive only)
- [ ] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)