### PR TITLE
chore(release): 🔖 prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ _No unreleased changes._
 
 ---
 
+## [0.6.0] - 2026-02-08
+
+### Added
+
+- **Runtime**: Fan-out operator for derived work execution — `emit.enqueue()` events now trigger child runs at runtime, enabling discovery-driven extraction chains (list → detail → asset) without external orchestrators (#117)
+- **CLI**: `--depth` flag to set maximum fan-out recursion depth (root = depth 0); required for fan-out activation (#117)
+- **CLI**: `--max-runs` flag to cap total child runs (required when `--depth > 0` as a safety rail against unbounded fan-out) (#117)
+- **CLI**: `--parallel` flag to control concurrent child run execution (default: 1, sequential) (#117)
+- **Docs**: Derived work execution design replacing crawl mode concept (#116)
+- **Docs**: Ingress models exploration document (#115)
+- **Docs**: Temporal orchestration integration and module split documentation (#114)
+
+### Changed
+
+- **Lode**: Decoupled Lode from `cli/reader` dependency — cleaner module boundaries (#113)
+
+---
+
 ## [0.5.1] - 2026-02-08
 
 ### Fixed
@@ -279,6 +297,7 @@ _No unreleased changes._
 
 ---
 
+[0.6.0]: https://github.com/justapithecus/quarry/releases/tag/v0.6.0
 [0.5.1]: https://github.com/justapithecus/quarry/releases/tag/v0.5.1
 [0.5.0]: https://github.com/justapithecus/quarry/releases/tag/v0.5.0
 [0.4.1]: https://github.com/justapithecus/quarry/releases/tag/v0.4.1

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.5.1
+// Quarry Executor Bundle v0.6.0
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -1744,7 +1744,7 @@ import { dirname, resolve as resolve2 } from "node:path";
 
 // ../sdk/dist/index.mjs
 import { randomUUID } from "node:crypto";
-var CONTRACT_VERSION = "0.5.1";
+var CONTRACT_VERSION = "0.6.0";
 var TerminalEventError = class extends Error {
   constructor() {
     super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.5.1"
+const Version = "0.6.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.5.1' as const
+export const CONTRACT_VERSION = '0.6.0' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.5.1",
+    "contract_version": "0.6.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Lockstep version bump from 0.5.1 → 0.6.0 per AGENTS.md versioning policy. Rebuilds SDK and executor bundle with updated contract version. Adds CHANGELOG entry for v0.6.0.

## Highlights

- `quarry/types/version.go` → `0.6.0`
- `sdk/package.json` → `0.6.0`
- `sdk/src/types/events.ts` `CONTRACT_VERSION` → `0.6.0`
- Golden test fixtures updated for new contract version
- Executor bundle rebuilt with embedded SDK 0.6.0
- CHANGELOG.md v0.6.0 section covering fan-out operator (#117), design docs (#114–#116), and lode refactor (#113)

## Test plan

- [x] `go build ./...` — compiles
- [x] `go test ./...` — all Go tests pass
- [x] `go vet ./...` — clean
- [x] `pnpm -C sdk run test` — all 172 SDK tests pass (including golden fixtures)
- [x] `task lint` — golangci-lint + biome clean
- [x] `task executor:bundle` — bundle rebuilt at v0.6.0
- [x] No stale `0.5.1` references outside CHANGELOG history

🤖 Generated with [Claude Code](https://claude.com/claude-code)