### PR TITLE
docs(runtime): 📝 add fan-out documentation and v0.6.0 version bumps

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.5.0.
+User-facing guide for Quarry v0.6.0.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,14 +26,14 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:justapithecus/quarry@0.5.0
+mise install github:justapithecus/quarry@0.6.0
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:justapithecus/quarry" = "0.5.0"
+"github:justapithecus/quarry" = "0.6.0"
 ```
 
 ### SDK
@@ -266,6 +266,14 @@ CLI flags always override config file values.
 | `--adapter-timeout <duration>` | `10s` | Notification timeout |
 | `--adapter-retries <n>` | `3` | Retry attempts |
 
+**Fan-out flags (derived work execution):**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--depth <n>` | `0` | Maximum recursion depth (0 = disabled) |
+| `--max-runs <n>` | | Total child run cap (required when `--depth > 0`) |
+| `--parallel <n>` | `1` | Maximum concurrent child runs |
+
 **Advanced flags (development only):**
 
 | Flag | Description |
@@ -395,13 +403,13 @@ task build
 
 ---
 
-## Known Limitations (v0.5.0)
+## Known Limitations (v0.6.0)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
 3. **No streaming reads**: Artifacts must fit in memory
 4. **S3 is experimental**: S3 and S3-compatible providers (R2, MinIO) are supported but experimental; no transactional guarantees across writes
-5. **No job scheduling**: Quarry is an execution runtime, not a scheduler
+5. **No job scheduling**: Quarry supports in-process derived work via `--depth` but is not a scheduler; external orchestration is the caller's responsibility
 6. **Puppeteer required**: All scripts run in a browser context
 7. **Event bus adapters**: Webhook and Redis pub/sub adapters are available. Temporal, NATS, and SNS adapters are planned. See `docs/guides/integration.md`.
 
@@ -466,7 +474,7 @@ export AWS_SECRET_ACCESS_KEY=<secret-key>
 Quarry is an extraction runtime, not a full pipeline. For triggering downstream
 processing after runs complete, see [docs/guides/integration.md](docs/guides/integration.md).
 
-**Built-in adapters** (v0.5.0+): `--adapter webhook` sends an HTTP POST, and
+**Built-in adapters** (v0.6.0+): `--adapter webhook` sends an HTTP POST, and
 `--adapter redis` publishes to a Redis pub/sub channel after each run completes.
 See adapter flags above.
 
@@ -478,7 +486,7 @@ See adapter flags above.
 
 ```bash
 quarry version
-# 0.5.0 (commit: ...)
+# 0.6.0 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -487,6 +495,6 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.5.0` |
+| CLI binary | GitHub Releases | `mise install github:justapithecus/quarry@0.6.0` |
 | SDK | JSR | `npx jsr add @justapithecus/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @justapithecus/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:justapithecus/quarry@0.5.0
+mise install github:justapithecus/quarry@0.6.0
 ```
 
 ### SDK
@@ -142,6 +142,7 @@ Scripts are imperative, explicit, and boring by design.
 - **Streaming** — chunked artifacts with backpressure → [docs/guides/streaming.md](docs/guides/streaming.md)
 - **Configuration** — YAML project defaults via `--config` → [docs/guides/cli.md](docs/guides/cli.md)
 - **Integration** — webhook adapter for downstream triggers → [docs/guides/integration.md](docs/guides/integration.md)
+- **Fan-Out** — derived work execution via `emit.enqueue()` → [docs/guides/emit.md](docs/guides/emit.md)
 - **Run Lifecycle** — terminal states and exit codes → [docs/guides/run.md](docs/guides/run.md)
 
 ---

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.5.0
+# Support Posture — Quarry v0.6.0
 
-This document defines support expectations for Quarry v0.5.0.
+This document defines support expectations for Quarry v0.6.0.
 
 ---
 
 ## Maturity Level
 
-**v0.5.0 is an early release.** APIs and behaviors may change in subsequent
+**v0.6.0 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.5.0._
+_No known issues in v0.6.0._
 
 ---
 
@@ -30,6 +30,7 @@ _No known issues in v0.5.0._
 | Filesystem storage backend | Supported |
 | S3 storage backend | Experimental |
 | SDK emit API | Supported |
+| Fan-out (`--depth`) | Supported |
 
 ### Supported Platforms
 
@@ -128,12 +129,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.4.1 (commit: ...)
+# 0.6.0 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.5.0 is provided "as is" without warranty of any kind.
+Quarry v0.6.0 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/contracts/CONTRACT_CLI.md
+++ b/docs/contracts/CONTRACT_CLI.md
@@ -152,6 +152,25 @@ See CONTRACT_INTEGRATION.md for semantics.
 Adapter invocation is best-effort. Failures are logged to stderr.
 The run exit code is determined by execution outcome, never by adapter status.
 
+### Fan-Out Flags (v0.6.0+)
+
+`quarry run` supports optional derived work execution via enqueue events.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--depth` | int | `0` | Max fan-out recursion depth (0 = disabled) |
+| `--max-runs` | int | | Total child run cap (required when `--depth > 0`) |
+| `--parallel` | int | `1` | Max concurrent child runs |
+
+Semantics:
+- `--depth 0` (default): enqueue events are advisory only; no child runs.
+- `--depth > 0`: enqueue events trigger child runs up to the specified depth.
+- `--max-runs` is mandatory when `--depth > 0` (safety rail).
+- `--parallel > 1` without `--depth > 0` emits a stderr warning (no-op).
+- Deduplication: identical `(target, params)` pairs are executed once.
+- Exit code is determined by root run outcome only.
+- Child run results appear in the fan-out summary printed to stdout.
+
 ### Config File (v0.4.x+)
 
 `quarry run` supports an optional `--config <path>` flag that loads a YAML

--- a/docs/contracts/CONTRACT_EMIT.md
+++ b/docs/contracts/CONTRACT_EMIT.md
@@ -98,6 +98,12 @@ Semantics:
 - Advisory only; not guaranteed or required.
 - No feedback channel is implied.
 
+Runtime interpretation (v0.6.0+):
+- Default (`--depth 0`): advisory only, as above.
+- With `--depth > 0`: runtime schedules and executes as child runs.
+  Deduplication and depth limits are applied by the fan-out operator.
+  The contract itself is unchanged; runtime behavior depends on CLI flags.
+
 ### 5) `rotate_proxy` (optional advisory)
 Suggests the runtime consider rotating proxy/session identity.
 

--- a/docs/contracts/CONTRACT_RUN.md
+++ b/docs/contracts/CONTRACT_RUN.md
@@ -49,6 +49,18 @@ When applicable, the following fields must be set:
   - Incremented by 1 for each retry run.
   - A run with `attempt: 1` and no `parent_run_id` is an initial run.
 
+### Child Runs (v0.6.0+)
+
+When fan-out is active (`--depth > 0`), the runtime may create child runs
+in response to `enqueue` events. Child runs have:
+
+- A unique `run_id` (distinct from the parent).
+- `attempt: 1` (child runs are first attempts of derived work).
+- Depth tracked internally by the fan-out operator (not in the envelope).
+
+Child runs are **not** retries. They represent derived work from a different
+script, not a re-execution of the same job.
+
 ---
 
 ## Idempotency Expectations

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -131,6 +131,11 @@ Adapter flags (event-bus notification):
 - `--adapter-timeout <duration>` (per-request timeout, default: `10s`)
 - `--adapter-retries <n>` (retry attempts with exponential backoff, default: `3`)
 
+Fan-out flags (derived work execution):
+- `--depth <n>` (maximum recursion depth; 0 = disabled, default: `0`)
+- `--max-runs <n>` (total child run cap; required when `--depth > 0`)
+- `--parallel <n>` (concurrent child runs, default: `1`)
+
 Advanced flags:
 - `--executor <path>` (auto-resolved by default; override for troubleshooting)
 
@@ -180,6 +185,21 @@ quarry run \
   --storage-endpoint https://ACCOUNT_ID.r2.cloudflarestorage.com \
   --storage-s3-path-style \
   --job '{"url":"https://example.com"}'
+```
+
+Fan-out example (derived work execution):
+
+```
+quarry run \
+  --script ./listing.ts \
+  --run-id root-001 \
+  --source demo \
+  --storage-backend fs \
+  --storage-path ./quarry-data \
+  --job '{"start_url":"https://example.com/listings"}' \
+  --depth 1 \
+  --max-runs 50 \
+  --parallel 4
 ```
 
 #### Job Payload Contract

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -111,6 +111,18 @@ See `docs/guides/proxy.md` for pool configuration format and selection behavior.
 
 See `docs/guides/integration.md` for adapter usage patterns.
 
+### Fan-Out (Derived Work Execution)
+
+| Flag | Type | Default | Purpose |
+|------|------|---------|---------|
+| `--depth` | int | `0` | Max recursion depth (0 = disabled) |
+| `--max-runs` | int | | Total child run cap (required when `--depth > 0`) |
+| `--parallel` | int | `1` | Max concurrent child runs |
+
+When `--depth > 0`, enqueue events emitted by scripts trigger child runs
+at runtime. `--max-runs` is mandatory as a safety rail.
+`--parallel > 1` without `--depth > 0` emits a warning (no-op).
+
 ### Output
 
 | Flag | Type | Default | Purpose |

--- a/docs/guides/emit.md
+++ b/docs/guides/emit.md
@@ -51,6 +51,19 @@ intent but carry no delivery or execution guarantee.
 
 Scripts should not depend on advisory events being acted upon.
 
+### Fan-Out Activation (v0.6.0+)
+
+When `quarry run` is invoked with `--depth <n>` (where n > 0), the runtime
+**acts on** enqueue events by executing them as child runs:
+
+- `target` names the script to execute (resolved relative to CWD).
+- `params` becomes the child run's job payload.
+- Identical `(target, params)` pairs are deduplicated.
+- Child runs can themselves emit enqueue events (up to the depth limit).
+
+Without `--depth`, enqueue remains purely advisory. The emit contract is
+unchanged; the runtime's interpretation depends on CLI flags.
+
 ---
 
 ## Convenience Log Methods

--- a/docs/guides/run.md
+++ b/docs/guides/run.md
@@ -29,3 +29,21 @@ Runs end in one of a few outcomes:
 - policy failure
 
 Each outcome is observable in runtime metadata.
+
+---
+
+## Child Runs (Fan-Out)
+
+When `--depth > 0` is set, scripts can trigger **child runs** via
+`emit.enqueue()`. Child runs differ from retry runs:
+
+| | Retry Run | Child Run |
+|-|-----------|-----------|
+| Trigger | Failure of previous run | `emit.enqueue()` from parent |
+| Script | Same as parent | Specified by `target` field |
+| `attempt` | Incremented | Always 1 |
+| `job_id` | Same as parent | New (derived from parent) |
+
+Child runs are tracked internally by the fan-out operator. The root run's
+exit code determines the overall outcome; child run results appear in the
+fan-out summary.


### PR DESCRIPTION
## Summary

Add user-facing documentation for the fan-out operator shipped in v0.6.0 (#117) and bump all remaining v0.5.0 references to v0.6.0 across root docs, guides, and contracts.

## Highlights

- Bump `0.5.0` → `0.6.0` in PUBLIC_API.md, README.md, SUPPORT.md (install commands, version output, headings, warranty)
- Add fan-out flag tables (`--depth`, `--max-runs`, `--parallel`) to cli.md, configuration.md, PUBLIC_API.md, CONTRACT_CLI.md
- Add behavioral clarifications for fan-out to emit.md (fan-out activation), run.md (child runs vs retries), CONTRACT_EMIT.md (runtime interpretation), CONTRACT_RUN.md (child run semantics)
- Add fan-out entry to README Key Concepts and SUPPORT supported components
- Update Known Limitations to reflect in-process derived work via `--depth`

## Test plan

- [ ] Grep for remaining `0.5.0` references in modified files — none expected
- [ ] All markdown links resolve correctly
- [ ] Contract sections consistent with fan-out implementation in run.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)