### PR TITLE
docs(runtime): 📝 add fan-out-chain example for derived work execution

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,11 @@ Renders a local fixture and emits a screenshot artifact:
 Tests the error path by throwing after one item:
 - `examples/intentional-failure/`
 
+## fan-out-chain
+
+Demonstrates fan-out derived work execution (list → detail):
+- `examples/fan-out-chain/`
+
 ## integration-patterns
 
 Conceptual examples for downstream event-bus and polling integration:

--- a/examples/fan-out-chain/README.md
+++ b/examples/fan-out-chain/README.md
@@ -1,0 +1,20 @@
+# fan-out-chain
+
+Demonstrates fan-out derived work execution. The root script parses a
+product listing and enqueues a detail script per product. Each detail
+script extracts product data and emits an item.
+
+Run:
+
+```
+quarry run \
+  --script ./examples/fan-out-chain/listing.ts \
+  --run-id fanout-001 \
+  --source demo \
+  --storage-backend fs \
+  --storage-path ./quarry-data \
+  --job '{}' \
+  --depth 1 \
+  --max-runs 10 \
+  --parallel 3
+```

--- a/examples/fan-out-chain/detail.ts
+++ b/examples/fan-out-chain/detail.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { QuarryContext } from "@justapithecus/quarry-sdk";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type DetailJob = {
+  product_id: string;
+  fixture: string;
+};
+
+/**
+ * Child script: reads a product detail fixture and emits a single item
+ * with the extracted product data.
+ */
+export default async function run(ctx: QuarryContext): Promise<void> {
+  const job = ctx.job as DetailJob;
+
+  const html = await readFile(
+    resolve(__dirname, "fixtures", job.fixture),
+    "utf8"
+  );
+  await ctx.page.setContent(html, { waitUntil: "domcontentloaded" });
+
+  const product = await ctx.page.$eval(".product-detail", (el) => ({
+    id: el.getAttribute("data-id") ?? "",
+    title: el.querySelector(".title")?.textContent?.trim() ?? "",
+    price: el.querySelector(".price")?.textContent?.trim() ?? "",
+    description:
+      el.querySelector(".description")?.textContent?.trim() ?? ""
+  }));
+
+  await ctx.emit.item({
+    item_type: "product",
+    data: product
+  });
+}

--- a/examples/fan-out-chain/fixtures/detail-1.html
+++ b/examples/fan-out-chain/fixtures/detail-1.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Widget Alpha</title>
+  </head>
+  <body>
+    <div class="product-detail" data-id="1">
+      <h1 class="title">Widget Alpha</h1>
+      <span class="price">9.99</span>
+      <p class="description">A compact and versatile alpha widget.</p>
+    </div>
+  </body>
+</html>

--- a/examples/fan-out-chain/fixtures/detail-2.html
+++ b/examples/fan-out-chain/fixtures/detail-2.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Widget Beta</title>
+  </head>
+  <body>
+    <div class="product-detail" data-id="2">
+      <h1 class="title">Widget Beta</h1>
+      <span class="price">14.50</span>
+      <p class="description">An enhanced beta widget with extra features.</p>
+    </div>
+  </body>
+</html>

--- a/examples/fan-out-chain/fixtures/detail-3.html
+++ b/examples/fan-out-chain/fixtures/detail-3.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Widget Gamma</title>
+  </head>
+  <body>
+    <div class="product-detail" data-id="3">
+      <h1 class="title">Widget Gamma</h1>
+      <span class="price">24.00</span>
+      <p class="description">The premium gamma widget for demanding workloads.</p>
+    </div>
+  </body>
+</html>

--- a/examples/fan-out-chain/fixtures/listing.html
+++ b/examples/fan-out-chain/fixtures/listing.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Product Listing</title>
+  </head>
+  <body>
+    <h1>Products</h1>
+    <ul id="products">
+      <li class="product" data-id="1">
+        <a href="/products/1">Widget Alpha</a>
+      </li>
+      <li class="product" data-id="2">
+        <a href="/products/2">Widget Beta</a>
+      </li>
+      <li class="product" data-id="3">
+        <a href="/products/3">Widget Gamma</a>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/examples/fan-out-chain/listing.ts
+++ b/examples/fan-out-chain/listing.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { QuarryContext } from "@justapithecus/quarry-sdk";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Root script: parses a product listing fixture and enqueues a detail
+ * script for each product found.
+ */
+export default async function run(ctx: QuarryContext): Promise<void> {
+  const html = await readFile(
+    resolve(__dirname, "fixtures/listing.html"),
+    "utf8"
+  );
+  await ctx.page.setContent(html, { waitUntil: "domcontentloaded" });
+
+  const products = await ctx.page.$$eval("li.product", (els) =>
+    els.map((el) => ({
+      id: el.getAttribute("data-id") ?? "",
+      name: el.querySelector("a")?.textContent?.trim() ?? ""
+    }))
+  );
+
+  for (const product of products) {
+    await ctx.emit.enqueue({
+      target: "./examples/fan-out-chain/detail.ts",
+      params: {
+        product_id: product.id,
+        fixture: `detail-${product.id}.html`
+      }
+    });
+  }
+}

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -61,6 +61,23 @@
         "terminal": "run_error",
         "exit_code": 1
       }
+    },
+    {
+      "name": "fan-out-chain",
+      "script": "fan-out-chain/listing.ts",
+      "description": "Fan-out derived work execution (listing → detail)",
+      "fan_out": {
+        "depth": 1,
+        "max_runs": 10,
+        "parallel": 3
+      },
+      "expected": {
+        "events": {
+          "enqueue": 3,
+          "item": 3
+        },
+        "terminal": "run_complete"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add a runnable fan-out chain example that demonstrates `emit.enqueue()` with `--depth` for derived work execution. The example uses a two-level listing → detail pattern with local HTML fixtures.

## Highlights

- Root script (`listing.ts`) parses a product listing fixture and calls `emit.enqueue()` for each of 3 products
- Child script (`detail.ts`) reads product detail fixtures and emits a single `item` per product
- All fixtures are self-contained HTML (no CSS/JS, no network) matching existing example patterns
- Added to `manifest.json` with `fan_out` config and expected event counts
- Updated `examples/README.md` with fan-out-chain entry

## Test plan

- [ ] Scripts follow existing patterns (default export, `QuarryContext`, local fixtures, `__dirname` resolution)
- [ ] Example runs successfully: `quarry run --script ./examples/fan-out-chain/listing.ts --run-id test --source demo --storage-backend fs --storage-path /tmp/quarry-test --job '{}' --depth 1 --max-runs 10 --parallel 3`
- [ ] Fan-out summary shows 3 child runs (one per detail page)
- [ ] Each child run emits 1 item with product data

🤖 Generated with [Claude Code](https://claude.com/claude-code)