### PR TITLE
fix(runtime): 🐛 fail fast on file_write without FileWriter and increase metrics timeout

### DIFF
--- a/quarry/cli/cmd/run.go
+++ b/quarry/cli/cmd/run.go
@@ -381,7 +381,7 @@ func (cf *childFactory) Run(ctx context.Context, item runtime.WorkItem, observer
 
 	// Persist child metrics (best effort)
 	if childLodeClient != nil {
-		metricsCtx, metricsCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		metricsCtx, metricsCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		if writeErr := childLodeClient.WriteMetrics(metricsCtx, childCollector.Snapshot(), time.Now()); writeErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to persist child metrics for %s: %v\n", item.RunID, writeErr)
 		}
@@ -421,7 +421,7 @@ func (f *runFinalizer) persistMetrics(duration time.Duration) {
 		return
 	}
 	completedAt := f.startTime.Add(duration)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := f.lodeClient.WriteMetrics(ctx, f.collector.Snapshot(), completedAt); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to persist metrics: %v\n", err)

--- a/quarry/runtime/ingestion.go
+++ b/quarry/runtime/ingestion.go
@@ -519,10 +519,10 @@ func (e *IngestionEngine) processFileWrite(ctx context.Context, frame *types.Fil
 	}
 
 	if e.fileWriter == nil {
-		e.logger.Warn("file_write received but no FileWriter configured, ignoring", map[string]any{
-			"filename": frame.Filename,
-		})
-		return nil
+		return &IngestionError{
+			Kind: IngestionErrorStream,
+			Err:  errors.New("file_write received but no FileWriter configured; ensure storage is properly configured for sidecar file support"),
+		}
 	}
 
 	if err := e.fileWriter.PutFile(ctx, frame.Filename, frame.ContentType, frame.Data); err != nil {


### PR DESCRIPTION
## Summary

`storage.put()` previously logged a warning and silently discarded data when FileWriter was nil. This surfaced as silent data loss for runs depending on sidecar file support. Now returns an `IngestionErrorStream` to fail the run immediately. Also increases metrics persistence timeout from 10s to 30s to match policy flush window.

## Highlights

- `processFileWrite` returns `IngestionErrorStream` when FileWriter is nil
- Metrics `WriteMetrics` timeout: 10s → 30s (child + root finalizer)
- New test: `TestIngestionEngine_FileWrite_NoFileWriter_FailsFast`

## Test plan

- [ ] `go test ./...` passes
- [ ] New ingestion test verifies stream error on nil FileWriter
- [ ] Existing tests confirm no regressions from fail-fast change

🤖 Generated with [Claude Code](https://claude.com/claude-code)