### PR TITLE
chore(release): v0.6.3 — version mismatch detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ _No unreleased changes._
 
 ---
 
+## [0.6.3] - 2026-02-09
+
+### Fixed
+
+- **Runtime**: SDK/CLI version mismatches are now classified as `version_mismatch` instead of `executor_crash`, with an actionable error message directing users to align their SDK and CLI versions (#132)
+
+### Changed
+
+- **Runtime**: Version mismatch errors increment `run_failed` (not `run_crashed`) and do not fire `executor_crash` metric (#132)
+- **CLI**: `version_mismatch` outcome maps to exit code 3 (non-retryable, same as `policy_failure`) (#132)
+- **Contracts**: `CONTRACT_RUN.md` and `CONTRACT_INTEGRATION.md` now enumerate `version_mismatch` as a fifth outcome status (#132)
+
+---
+
 ## [0.6.2] - 2026-02-08
 
 ### Added

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.6.2
+// Quarry Executor Bundle v0.6.3
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.6.2";
+    CONTRACT_VERSION = "0.6.3";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.6.2"
+const Version = "0.6.3"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justapithecus/quarry-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.6.2' as const
+export const CONTRACT_VERSION = '0.6.3' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.6.2",
+    "contract_version": "0.6.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Lockstep version bump to 0.6.3. Ships the version mismatch detection from #132/#133.

### What's in 0.6.3

- **Fixed**: SDK/CLI version mismatches now produce `version_mismatch` outcome instead of `executor_crash`, with actionable guidance
- **Changed**: Version mismatch metrics go to `run_failed` (not `run_crashed`), CLI exit code 3 (non-retryable)
- **Changed**: `CONTRACT_RUN.md` and `CONTRACT_INTEGRATION.md` enumerate `version_mismatch` as a fifth outcome status

### Lockstep components bumped

| Component | File |
|-----------|------|
| Go canonical | `quarry/types/version.go` |
| SDK package | `sdk/package.json` |
| SDK contract constant | `sdk/src/types/events.ts` |
| Executor bundle | `quarry/executor/bundle/executor.mjs` (rebuilt) |
| Changelog | `CHANGELOG.md` |

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `task version:lockstep` — Go and SDK match at 0.6.3
- [x] Bundle freshness — `CONTRACT_VERSION = "0.6.3"` in embedded bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)