### PR TITLE
chore(deps): bump lode v0.7.0 → v0.7.1

### DIFF
--- a/quarry/go.mod
+++ b/quarry/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
-	github.com/justapithecus/lode v0.7.0
+	github.com/justapithecus/lode v0.7.1
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/quarry/go.sum
+++ b/quarry/go.sum
@@ -92,8 +92,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/justapithecus/lode v0.7.0 h1:ZDfnpQxqhokwYiLZoUdoshwxUjCn8tjpp+QpNXe8Bzw=
-github.com/justapithecus/lode v0.7.0/go.mod h1:v7yRsnSijCvSud1Zl8WNllaUpYH6l7szFavJswKEi/8=
+github.com/justapithecus/lode v0.7.1 h1:ZdeVE9QgoyDuozrjt8bC14a44cK3VllrUCTQ6saYqug=
+github.com/justapithecus/lode v0.7.1/go.mod h1:v7yRsnSijCvSud1Zl8WNllaUpYH6l7szFavJswKEi/8=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
 github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=


### PR DESCRIPTION
## Summary

Upgrades Lode from v0.7.0 to v0.7.1 to pick up the snapshot ID caching fix (pithecene-io/lode#108).

**Root cause**: `dataset.Write()` performed linear snapshot ID lookups on every flush, resulting in O(n²) behavior under sustained write load. v0.7.1 caches snapshot IDs, restoring O(1) flush cost.

This is the last dependency change before tagging v0.6.3.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)