### PR TITLE
docs(contracts): add exit codes, outcome→metric mapping for version_mismatch

### DIFF
--- a/docs/contracts/CONTRACT_CLI.md
+++ b/docs/contracts/CONTRACT_CLI.md
@@ -135,6 +135,21 @@ CONTRACT_EMIT.md and CONTRACT_POLICY.md.
 
 No other command may initiate or control execution.
 
+### Exit Codes
+
+The `run` command exit code is determined by execution outcome:
+
+| Exit Code | OutcomeStatus | Meaning |
+|-----------|---------------|---------|
+| 0 | `success` | Run completed successfully |
+| 1 | `script_error` | Script emitted `run_error` |
+| 2 | `executor_crash` | Executor crashed or exited abnormally |
+| 3 | `policy_failure` | Ingestion policy failed (non-retryable) |
+| 3 | `version_mismatch` | SDK/CLI contract version mismatch (non-retryable) |
+
+`policy_failure` and `version_mismatch` share exit code 3 because both
+are non-retryable configuration errors that cannot be resolved by re-running.
+
 ### Adapter Flags (v0.5.0+)
 
 `quarry run` supports optional event-bus adapter notification.
@@ -373,8 +388,9 @@ MetricsSnapshot:
   lode_write_retry_total: number
 ```
 
-Metric names match CONTRACT_METRICS.md. Dimensions are included for
-traceability.
+Metric names match CONTRACT_METRICS.md. See CONTRACT_METRICS.md for the
+outcome-to-metric mapping (which outcomes increment which counters).
+Dimensions are included for traceability.
 
 Usage examples:
 ```

--- a/docs/contracts/CONTRACT_METRICS.md
+++ b/docs/contracts/CONTRACT_METRICS.md
@@ -48,6 +48,20 @@ Non-goals:
 - `runs_failed_total` (counter)
 - `runs_crashed_total` (counter)
 
+Outcome-to-metric mapping:
+
+| OutcomeStatus | Counter Incremented |
+|---------------|---------------------|
+| `success` | `runs_completed_total` |
+| `script_error` | `runs_failed_total` |
+| `policy_failure` | `runs_failed_total` |
+| `version_mismatch` | `runs_failed_total` |
+| `executor_crash` | `runs_crashed_total` |
+
+`version_mismatch` increments `runs_failed_total` (not `runs_crashed_total`)
+because it is a configuration error, not an executor fault. It also does NOT
+increment `executor_crash_total`.
+
 ### Ingestion Policy
 - `events_received_total` (counter)
 - `events_persisted_total` (counter)


### PR DESCRIPTION
## Summary

Fixes three contract documentation gaps identified during the v0.6.3 release review.

### 1. CONTRACT_CLI.md — exit code table (new)
The CLI contract defined command topology and flags but never documented exit codes. Added a table mapping `OutcomeStatus` → exit code, including `version_mismatch` sharing exit code 3 with `policy_failure`.

### 2. CONTRACT_METRICS.md — outcome→metric mapping (new)
Added a table clarifying which outcome increments which run lifecycle counter. Documents that `version_mismatch` increments `runs_failed_total` (not `runs_crashed_total`) and does not fire `executor_crash_total`.

### 3. CONTRACT_CLI.md `stats metrics` — cross-reference
Added a reference to CONTRACT_METRICS.md for the outcome-to-counter mapping so integrators reading the stats response schema know where to find the semantics.

## Test plan

- Docs-only change (no code modified)
- [x] Verified exit code table matches `quarry/cli/cmd/run.go:33-37` and `outcomeToExitCode()`
- [x] Verified metric mapping matches `quarry/runtime/run.go` `buildResult()` switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)