### PR TITLE
docs(contracts): 📝 documentation sweep for v0.7.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- **Policy**: `streaming` ingestion policy — combines strict's no-drop guarantee with buffered's batched write efficiency for long-running crawl workloads (#140)
+- **Policy**: Configurable flush triggers: `--flush-count` (event count threshold) and `--flush-interval` (time-based periodic flush) (#140)
+- **Policy**: Capacity-triggered emergency flush prevents deadlock when internal buffer bounds are reached before configured triggers fire (#140)
+- **Policy**: Backpressure-based flow control — ingestion blocks when buffer is full rather than dropping events (#140)
+- **Proxy**: `recency_window` pool option — maintains a ring buffer of recently-used endpoint indices and excludes them from random selection, reducing endpoint reuse (#143)
+- **Proxy**: LRU fallback when recency window >= endpoint count (selection never blocks) (#143)
+- **Testing**: Performance benchmarks for all ingestion policies (strict, buffered, streaming) with contention analysis (#144)
+- **Docs**: Streaming policy contract section in CONTRACT_POLICY.md (#139)
+
+### Changed
+
+- **Metrics**: `flush_triggers` counter added to metrics snapshot — per-trigger-type flush counts (`count`, `interval`, `termination`, `capacity`) for streaming policy observability (#140)
+- **Internal**: `statsRecorder` converted from mutex-based to `sync/atomic` counters — 3.7x improvement in 8-goroutine contention benchmarks (#144)
 
 ---
 

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -253,10 +253,16 @@ CLI flags always override config file values.
 | `--job <json>` | `{}` | Job payload as inline JSON object |
 | `--job-json <path>` | | Path to JSON file containing job payload (must be object) |
 | `--category <name>` | `default` | Category for partitioning |
-| `--policy <strict\|buffered>` | `strict` | Ingestion policy |
+| `--policy <strict\|buffered\|streaming>` | `strict` | Ingestion policy |
+| `--flush-count <n>` | | Flush after N events (streaming policy) |
+| `--flush-interval <duration>` | | Flush every interval, e.g. `5s` (streaming policy) |
 
 > **Note:** `--job` and `--job-json` are mutually exclusive. Using both is an error.
 > The payload **must** be a top-level JSON object. Arrays, primitives, and null are rejected.
+
+> **Streaming policy:** At least one of `--flush-count` or `--flush-interval` must be specified
+> when `--policy=streaming`. Both may be specified; the first trigger to fire wins.
+> See `docs/guides/policy.md` for details.
 
 **Adapter flags (event-bus notification):**
 
@@ -416,7 +422,7 @@ task build
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
-3. **No streaming reads**: Artifacts must fit in memory
+3. **No streaming reads**: Artifacts must fit in memory (note: the `streaming` *ingestion policy* is unrelated — it controls write batching, not read access)
 4. **No transactional storage writes**: S3 and S3-compatible providers (R2, MinIO) do not provide transactional guarantees across writes
 5. **No job scheduling**: Quarry supports in-process derived work via `--depth` but is not a scheduler; external orchestration is the caller's responsibility
 6. **Puppeteer required**: All scripts run in a browser context

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,13 +13,13 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.6.3)
+## Current Status (as of v0.7.0-dev)
 - Latest release: v0.6.3 (see CHANGELOG.md).
 - Phases 0–5 complete. Phase 6 (dogfooding) in progress.
+- v0.7.0 features merged to main: streaming ingestion policy, recency window for proxy rotation, performance benchmarks. Version bump pending.
 - v0.6.x adds derived work execution (fan-out flags on `quarry run`).
 - v0.5.x adds webhook and Redis pub/sub event-bus adapters.
 - v0.4.x added `--config` for YAML project-level defaults and `ctx.storage.put()`.
-- Next priority: v0.7.0 streaming policy and advanced proxy rotation — see roadmap below.
 
 ---
 
@@ -588,15 +588,15 @@ When `--max-runs` is reached mid-execution:
 
 ### Mini-milestones
 
-- [ ] Contract updates (CONTRACT_EMIT.md enqueue semantics, CONTRACT_RUN.md
+- [x] Contract updates (CONTRACT_EMIT.md enqueue semantics, CONTRACT_RUN.md
       lineage fields, CONTRACT_CLI.md fan-out flags)
-- [ ] In-process scheduler: enqueue event interception, dedup, depth tracking
-- [ ] Child run spawning with concurrency limiter
-- [ ] `parent_run_id` and `depth` threading through run metadata
-- [ ] Fan-out flag wiring in `quarry/cli/cmd/run.go`
-- [ ] Summary output and exit code semantics
+- [x] In-process scheduler: enqueue event interception, dedup, depth tracking
+- [x] Child run spawning with concurrency limiter
+- [x] `parent_run_id` and `depth` threading through run metadata
+- [x] Fan-out flag wiring in `quarry/cli/cmd/run.go`
+- [x] Summary output and exit code semantics
 - [ ] `quarry inspect` fan-out lineage view
-- [ ] Tests: depth bounds, max-runs cap, concurrency, dedup, scheduling
+- [x] Tests: depth bounds, max-runs cap, concurrency, dedup, scheduling
       independence from ingestion policy
 
 ### Scope Boundary
@@ -660,11 +660,12 @@ near-real-time downstream visibility.
 
 #### Mini-milestones
 - [x] Contract sketch (CONTRACT_POLICY.md streaming section)
-- [ ] `StreamingPolicy` struct with count + interval flush triggers
-- [ ] Runtime integration: flush trigger goroutine in `Execute()`
-- [ ] CLI flag wiring and validation (`--policy=streaming` requires triggers)
-- [ ] Config YAML support (`policy.flush_count`, `policy.flush_interval`)
-- [ ] Tests: count trigger, interval trigger, combined, ordering, artifact integrity
+- [x] `StreamingPolicy` struct with count + interval flush triggers
+- [x] Runtime integration: flush trigger goroutine in `Execute()`
+- [x] CLI flag wiring and validation (`--policy=streaming` requires triggers)
+- [x] Config YAML support (`policy.flush_count`, `policy.flush_interval`)
+- [x] Tests: count trigger, interval trigger, combined, ordering, artifact integrity
+- [x] Performance benchmarks: strict, buffered, streaming contention analysis
 - [ ] Guide and configuration doc updates
 
 ### Advanced Proxy Rotation
@@ -694,12 +695,12 @@ recently-used endpoint indices and excludes them from random selection.
 - `quarry/cli/reader/types.go` — `RecencyWindow`/`RecencyFill` in `ProxyRuntime`
 
 #### Mini-milestones
-- [ ] Contract updated (`CONTRACT_PROXY.md` — recency semantics)
-- [ ] Guide updated (`docs/guides/proxy.md` — user-facing docs)
-- [ ] Go types and validation (`quarry/types/proxy.go`)
-- [ ] Selector ring buffer and recency-aware random (`quarry/proxy/selector.go`)
-- [ ] SDK types and validation (`sdk/src/types/proxy.ts`, `sdk/src/proxy.ts`)
-- [ ] Tests: type validation, selector avoidance, LRU fallback, peek semantics
+- [x] Contract updated (`CONTRACT_PROXY.md` — recency semantics)
+- [x] Guide updated (`docs/guides/proxy.md` — user-facing docs)
+- [x] Go types and validation (`quarry/types/proxy.go`)
+- [x] Selector ring buffer and recency-aware random (`quarry/proxy/selector.go`)
+- [x] SDK types and validation (`sdk/src/types/proxy.ts`, `sdk/src/proxy.ts`)
+- [x] Tests: type validation, selector avoidance, LRU fallback, peek semantics
 
 ### Phase 2: Pluggable Recency Backend (Future)
 

--- a/docs/contracts/CONTRACT_CLI.md
+++ b/docs/contracts/CONTRACT_CLI.md
@@ -150,6 +150,24 @@ The `run` command exit code is determined by execution outcome:
 `policy_failure` and `version_mismatch` share exit code 3 because both
 are non-retryable configuration errors that cannot be resolved by re-running.
 
+### Streaming Policy Flags (v0.7.0+)
+
+`quarry run` supports a `streaming` ingestion policy with configurable flush
+triggers. At least one of `--flush-count` or `--flush-interval` must be
+specified when `--policy=streaming`.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--flush-count` | int | | Flush after N events accumulate |
+| `--flush-interval` | duration | | Flush every T duration (e.g. `5s`, `30s`) |
+
+Semantics:
+- Both may be specified; the first trigger to fire wins.
+- Buffer is bounded internally; if full before a trigger fires, ingestion
+  blocks until the next flush (events are never dropped).
+- On run termination, a final flush is always attempted (best effort).
+- Flush trigger counts are surfaced in `stats metrics` (see CONTRACT_METRICS.md).
+
 ### Adapter Flags (v0.5.0+)
 
 `quarry run` supports optional event-bus adapter notification.
@@ -386,6 +404,7 @@ MetricsSnapshot:
   lode_write_success_total: number
   lode_write_failure_total: number
   lode_write_retry_total: number
+  flush_triggers: map[string]number (optional, streaming policy only)
 ```
 
 Metric names match CONTRACT_METRICS.md. See CONTRACT_METRICS.md for the

--- a/docs/contracts/CONTRACT_METRICS.md
+++ b/docs/contracts/CONTRACT_METRICS.md
@@ -66,6 +66,21 @@ increment `executor_crash_total`.
 - `events_received_total` (counter)
 - `events_persisted_total` (counter)
 - `events_dropped_total` (counter, by event type)
+- `flush_triggers` (counter, by trigger type — streaming policy only)
+
+#### Flush Triggers (streaming policy)
+
+When `policy=streaming`, the runtime tracks per-trigger-type flush counts:
+
+| Trigger | Key | Description |
+|---------|-----|-------------|
+| Count threshold | `count` | Flush fired when `--flush-count` events accumulated |
+| Time interval | `interval` | Flush fired on `--flush-interval` tick |
+| Run termination | `termination` | Flush fired on `run_complete`, `run_error`, or runtime exit |
+| Buffer capacity | `capacity` | Emergency flush when internal buffer bounds reached |
+
+These are additive to the base policy counters. `flush_triggers` is `nil` for
+strict and buffered policies.
 
 ### Executor
 - `executor_launch_success_total` (counter)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -256,6 +256,26 @@ proxies:
         username: ${IPROYAL_USER}
         password: ${IPROYAL_PASS}
 
+  rotating_pool:
+    strategy: random
+    recency_window: 3   # avoid reusing the last 3 endpoints
+    endpoints:
+      - protocol: http
+        host: proxy1.example.com
+        port: 8080
+      - protocol: http
+        host: proxy2.example.com
+        port: 8080
+      - protocol: http
+        host: proxy3.example.com
+        port: 8080
+      - protocol: http
+        host: proxy4.example.com
+        port: 8080
+      - protocol: http
+        host: proxy5.example.com
+        port: 8080
+
   residential_sticky:
     strategy: sticky
     sticky:
@@ -419,6 +439,21 @@ quarry run \
   --policy buffered \
   --buffer-events 500 \
   --buffer-bytes 10485760
+```
+
+### Streaming policy (long-running crawl)
+
+```bash
+quarry run \
+  --script ./crawl.ts \
+  --run-id crawl-001 \
+  --source my-source \
+  --storage-backend s3 \
+  --storage-path my-bucket/quarry \
+  --storage-region us-east-1 \
+  --policy streaming \
+  --flush-count 100 \
+  --flush-interval 30s
 ```
 
 ### S3-compatible provider (Cloudflare R2)

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -23,7 +23,7 @@ At a high level:
 - **Job**: logical unit of work requested by a user or scheduler.
 - **Run**: a single execution attempt of a job.
 - **Attempt**: an integer counter for retries of the same job.
-- **Policy**: ingestion behavior (strict vs buffered).
+- **Policy**: ingestion behavior (strict, buffered, or streaming).
 
 ---
 

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -1,8 +1,13 @@
 # Streaming & Artifacts
 
 This document explains how events and artifacts flow between the executor
-and runtime. It is user-facing; the authoritative contract is
-`docs/contracts/CONTRACT_IPC.md`.
+and runtime (IPC-level streaming). It is user-facing; the authoritative
+contract is `docs/contracts/CONTRACT_IPC.md`.
+
+> **Not to be confused with** the `streaming` ingestion policy, which controls
+> write batching and flush triggers on the runtime side. For the streaming
+> ingestion policy, see `docs/guides/policy.md` and
+> `docs/contracts/CONTRACT_POLICY.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Update all documentation to reflect v0.7.0 features merged to main: streaming ingestion policy, recency window for proxy rotation, and performance benchmarks.

## Highlights

- **PUBLIC_API.md**: add `--flush-count`/`--flush-interval` flags, update `--policy` to include `streaming`, add streaming policy note
- **CONTRACT_METRICS.md**: add `flush_triggers` metric with trigger type enumeration (`count`, `interval`, `termination`, `capacity`)
- **CONTRACT_CLI.md**: add Streaming Policy Flags section, add `flush_triggers` to MetricsSnapshot response
- **CHANGELOG.md**: add v0.7.0 unreleased section documenting streaming policy (#140), recency window (#143), and benchmarks (#144)
- **IMPLEMENTATION_PLAN.md**: check off completed v0.6.0 fan-out and v0.7.0 milestones, update current status
- **configuration.md**: add streaming policy CLI recipe, add `recency_window` proxy pool YAML example
- **overview.md**: add streaming to policy enumeration
- **streaming.md**: add disambiguation note (IPC streaming vs streaming ingestion policy)

## Test plan

- [ ] Verify all 8 modified files render correctly
- [ ] Verify no broken cross-references
- [ ] Verify CHANGELOG unreleased section matches merged PR numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)