### PR TITLE
chore(agents): 🦺 add changelog and golden fixtures to release checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,9 +166,13 @@ When releasing:
 1. Update `quarry/types/version.go`
 2. Update `sdk/package.json` version field to match
 3. Update `sdk/src/types/events.ts` `CONTRACT_VERSION` to match
-4. Rebuild SDK (`pnpm exec tsdown` in sdk/)
-5. Rebuild executor bundle (`task executor:bundle`)
-6. Commit as a single version bump
+4. Update golden test fixtures (`sdk/test/emit/06-golden/*.json`) — they contain hardcoded `contract_version`
+5. Rebuild SDK (`pnpm exec tsdown` in sdk/)
+6. Rebuild executor bundle (`task executor:bundle`)
+7. Promote `CHANGELOG.md`: move `[Unreleased]` entries to a dated `[X.Y.Z] - YYYY-MM-DD` section, add the `[X.Y.Z]` link reference at the bottom, and restore an empty `[Unreleased]` placeholder
+8. Commit as a single version bump
+
+**This checklist is exhaustive. Do not skip steps. Do not split across commits.**
 
 ---
 


### PR DESCRIPTION
## Summary

The version bump checklist in AGENTS.md was missing two steps that have caused errors on consecutive releases: promoting CHANGELOG.md from `[Unreleased]` to a dated section, and updating golden test fixtures with the new `contract_version`.

## Highlights

- Add step 4: update golden test fixtures (`sdk/test/emit/06-golden/*.json`)
- Add step 7: promote CHANGELOG.md `[Unreleased]` → dated `[X.Y.Z]` section + link reference
- Add enforcement note: "This checklist is exhaustive. Do not skip steps."

## Test plan

- [ ] Checklist is clear and unambiguous
- [ ] All 8 steps match the actual release procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)