### PR TITLE
docs(readme): 📝 update docs for v0.7.0

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.6.2.
+User-facing guide for Quarry v0.7.0.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,14 +26,14 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:pithecene-io/quarry@0.6.2
+mise install github:pithecene-io/quarry@0.7.0
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:pithecene-io/quarry" = "0.6.2"
+"github:pithecene-io/quarry" = "0.7.0"
 ```
 
 ### SDK
@@ -288,6 +288,11 @@ CLI flags always override config file values.
 | Flag | Description |
 |------|-------------|
 | `--browser-ws-endpoint <url>` | Connect to an externally managed browser via WebSocket URL (skips per-run Chromium launch; see `docs/guides/cli.md`) |
+| `--no-browser-reuse` | Disable transparent browser reuse across runs (forces per-run Chromium launch) |
+
+By default, Quarry transparently reuses a persistent Chromium process across sequential runs.
+The browser auto-terminates after idle timeout (default 60s, configurable via `QUARRY_BROWSER_IDLE_TIMEOUT`).
+`--browser-ws-endpoint` takes priority over transparent reuse when set.
 
 **Advanced flags (development only):**
 
@@ -418,7 +423,7 @@ task build
 
 ---
 
-## Known Limitations (v0.6.2)
+## Known Limitations (v0.7.0)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -491,7 +496,7 @@ export AWS_SECRET_ACCESS_KEY=<secret-key>
 Quarry is an extraction runtime, not a full pipeline. For triggering downstream
 processing after runs complete, see [docs/guides/integration.md](docs/guides/integration.md).
 
-**Built-in adapters** (v0.6.2+): `--adapter webhook` sends an HTTP POST, and
+**Built-in adapters** (v0.5.0+): `--adapter webhook` sends an HTTP POST, and
 `--adapter redis` publishes to a Redis pub/sub channel after each run completes.
 See adapter flags above.
 
@@ -503,7 +508,7 @@ See adapter flags above.
 
 ```bash
 quarry version
-# 0.6.2 (commit: ...)
+# 0.7.0 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -512,6 +517,6 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.6.2` |
+| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.7.0` |
 | SDK | JSR | `npx jsr add @pithecene-io/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @pithecene-io/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:pithecene-io/quarry@0.6.2
+mise install github:pithecene-io/quarry@0.7.0
 ```
 
 ### SDK
@@ -53,7 +53,7 @@ emit.*  (stable event contract)
         ↓
 Quarry Runtime
         ↓
-Ingestion Policy (strict, buffered, etc.)
+Ingestion Policy (strict, buffered, streaming)
         ↓
 Persistence Substrate (e.g. Lode)
 ```
@@ -136,12 +136,13 @@ Scripts are imperative, explicit, and boring by design.
 ## Key Concepts
 
 - **Emit API** — all script output flows through `emit.*` → [docs/guides/emit.md](docs/guides/emit.md)
-- **Policies** — strict or buffered ingestion control → [docs/guides/policy.md](docs/guides/policy.md)
+- **Policies** — strict, buffered, or streaming ingestion control → [docs/guides/policy.md](docs/guides/policy.md)
 - **Storage** — FS and S3 backends via Lode → [docs/guides/lode.md](docs/guides/lode.md)
 - **Proxies** — pool-based rotation with multiple strategies → [docs/guides/proxy.md](docs/guides/proxy.md)
 - **Streaming** — chunked artifacts with backpressure → [docs/guides/streaming.md](docs/guides/streaming.md)
 - **Configuration** — YAML project defaults via `--config` → [docs/guides/cli.md](docs/guides/cli.md)
-- **Integration** — webhook adapter for downstream triggers → [docs/guides/integration.md](docs/guides/integration.md)
+- **Browser Reuse** — transparent Chromium persistence across sequential runs → [docs/guides/configuration.md](docs/guides/configuration.md)
+- **Integration** — webhook and Redis adapters for downstream triggers → [docs/guides/integration.md](docs/guides/integration.md)
 - **Fan-Out** — derived work execution via `emit.enqueue()` → [docs/guides/emit.md](docs/guides/emit.md)
 - **Run Lifecycle** — terminal states and exit codes → [docs/guides/run.md](docs/guides/run.md)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.6.2
+# Support Posture — Quarry v0.7.0
 
-This document defines support expectations for Quarry v0.6.2.
+This document defines support expectations for Quarry v0.7.0.
 
 ---
 
 ## Maturity Level
 
-**v0.6.2 is an early release.** APIs and behaviors may change in subsequent
+**v0.7.0 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.6.2._
+_No known issues in v0.7.0._
 
 ---
 
@@ -128,12 +128,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.6.2 (commit: ...)
+# 0.7.0 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.6.2 is provided "as is" without warranty of any kind.
+Quarry v0.7.0 is provided "as is" without warranty of any kind.
 See LICENSE for details.


### PR DESCRIPTION
## Summary

Update README, PUBLIC_API.md, and SUPPORT.md for v0.7.0. All three had stale v0.6.2 references and were missing browser reuse documentation.

## Highlights

- **README**: Bump install version 0.6.2 → 0.7.0, add streaming policy, browser reuse, and Redis adapter to Key Concepts
- **PUBLIC_API.md**: Bump all v0.6.2 → v0.7.0 references (header, install, mise pin, known limitations, version output, distribution table), add `--no-browser-reuse` flag and `QUARRY_BROWSER_IDLE_TIMEOUT` docs to browser reuse section
- **SUPPORT.md**: Bump all v0.6.2 → v0.7.0 references (title, maturity, known issues, version output, warranty)

## Test plan

- [x] No remaining stale 0.6.2 references in README, PUBLIC_API, or SUPPORT
- [x] All linked guide paths exist
- [x] --no-browser-reuse flag documented in CLI reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)