### PR TITLE
chore: 🔖 bump lockstep version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ _No unreleased changes._
 
 ---
 
+## [0.7.1] - 2026-02-11
+
+### Added
+
+- **Distribution**: Containerized distribution via GHCR — `ghcr.io/pithecene-io/quarry:0.7.1` (full, with system Chromium + fonts) and `ghcr.io/pithecene-io/quarry:0.7.1-slim` (no browser, BYO Chromium via `--browser-ws-endpoint`) (#152)
+- **CI**: Dockerfile lint check (`docker build --check`) in PR and main CI workflows (#152)
+- **Testing**: Integration test for terminal frame visibility at pipe boundary — pins the stdout flush race that caused false `executor_crash` classification (#153)
+
+### Fixed
+
+- **Executor**: Drain stdout before `process.exit()` to prevent false `executor_crash` — `process.exit()` was discarding buffered stdout data before it reached the OS pipe, causing the Go runtime to see EOF without a terminal event and classify successful runs as `executor_crash` (#153)
+
+---
+
 ## [0.7.0] - 2026-02-10
 
 ### Added
@@ -363,6 +377,7 @@ _No unreleased changes._
 
 ---
 
+[0.7.1]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.1
 [0.7.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.0
 [0.6.3]: https://github.com/pithecene-io/quarry/releases/tag/v0.6.3
 [0.6.2]: https://github.com/pithecene-io/quarry/releases/tag/v0.6.2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:pithecene-io/quarry@0.7.0
+mise install github:pithecene-io/quarry@0.7.1
+```
+
+### Docker
+
+```bash
+# Full image (includes Chromium + fonts)
+docker pull ghcr.io/pithecene-io/quarry:0.7.1
+
+# Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
+docker pull ghcr.io/pithecene-io/quarry:0.7.1-slim
 ```
 
 ### SDK
@@ -168,7 +178,7 @@ Quarry is under active development.
 
 - Contracts frozen, SDK stable
 - FS and S3 storage supported
-- Platforms: linux/darwin, x64/arm64
+- Platforms: linux/darwin, x64/arm64, container (GHCR)
 
 Breaking changes are gated by contract versioning.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.7.0
+# Support Posture — Quarry v0.7.1
 
-This document defines support expectations for Quarry v0.7.0.
+This document defines support expectations for Quarry v0.7.1.
 
 ---
 
 ## Maturity Level
 
-**v0.7.0 is an early release.** APIs and behaviors may change in subsequent
+**v0.7.1 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.7.0._
+_No known issues in v0.7.1._
 
 ---
 
@@ -38,6 +38,7 @@ _No known issues in v0.7.0._
 |----------|--------|
 | Linux (x64, arm64) | Supported |
 | macOS (x64, arm64) | Supported |
+| Container (GHCR) | Supported |
 | Windows | Not tested |
 
 ### Supported Runtimes
@@ -135,5 +136,5 @@ quarry version
 
 ## No Warranty
 
-Quarry v0.7.0 is provided "as is" without warranty of any kind.
+Quarry v0.7.1 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/executor-node/test/ipc/fixtures/drain-stdout-child.ts
+++ b/executor-node/test/ipc/fixtures/drain-stdout-child.ts
@@ -12,7 +12,7 @@ const sink = new StdioSink(process.stdout)
 
 // Item event
 await sink.writeEvent({
-  contract_version: '0.7.0',
+  contract_version: '0.7.1',
   event_id: 'evt-1' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 1,
@@ -24,7 +24,7 @@ await sink.writeEvent({
 
 // Terminal event (run_complete)
 await sink.writeEvent({
-  contract_version: '0.7.0',
+  contract_version: '0.7.1',
   event_id: 'evt-2' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 2,

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.7.0
+// Quarry Executor Bundle v0.7.1
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.7.0";
+    CONTRACT_VERSION = "0.7.1";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/policy/benchmark_test.go
+++ b/quarry/policy/benchmark_test.go
@@ -16,7 +16,7 @@ import (
 // benchEnvelope returns a realistic event envelope for benchmarks.
 func benchEnvelope(seq int64) *types.EventEnvelope {
 	return &types.EventEnvelope{
-		ContractVersion: "0.7.0",
+		ContractVersion: "0.7.1",
 		EventID:         fmt.Sprintf("evt-%d", seq),
 		RunID:           "bench-run-001",
 		Seq:             seq,
@@ -232,7 +232,7 @@ func BenchmarkBufferedPolicy_DropPressure(b *testing.B) {
 
 	// Droppable event that will be dropped on each iteration
 	droppable := &types.EventEnvelope{
-		ContractVersion: "0.7.0",
+		ContractVersion: "0.7.1",
 		EventID:         "drop-001",
 		RunID:           "bench-run-001",
 		Seq:             100,

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.7.0"
+const Version = "0.7.1"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.7.0' as const
+export const CONTRACT_VERSION = '0.7.1' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.7.0",
+    "contract_version": "0.7.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Version bump for v0.7.1 release. Includes containerized distribution via GHCR and the stdout flush fix that eliminates false `executor_crash` classification.

## Highlights

- Bump all lockstep versions to 0.7.1: `version.go`, `sdk/package.json`, `CONTRACT_VERSION`, golden fixtures, benchmark test, drain-stdout fixture
- Rebuild SDK and executor bundle at v0.7.1
- Promote CHANGELOG.md: move Unreleased entries to dated `[0.7.1]` section
- Add container usage docs to PUBLIC_API.md — standalone `docker run`, Docker Compose (FS and S3), slim image with external browser sidecar
- Add Docker installation section to README.md
- Add container platform to SUPPORT.md
- Update all user-facing version references from 0.7.0 → 0.7.1

## Test plan

- [x] `task test` — all Go + TS tests pass (286 total)
- [x] `task examples` — all 6 examples pass
- [x] Golden fixtures updated and passing
- [x] Executor bundle rebuilt at v0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)