### PR TITLE
fix(ci): ⚡️ build slim image before full to maximize cache reuse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,19 +354,6 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: 🐳 Build & push (full)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: full
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/pithecene-io/quarry:${{ steps.version.outputs.version }}
-            ghcr.io/pithecene-io/quarry:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: 🐳 Build & push (slim)
         uses: docker/build-push-action@v6
         with:
@@ -377,5 +364,18 @@ jobs:
           tags: |
             ghcr.io/pithecene-io/quarry:${{ steps.version.outputs.version }}-slim
             ghcr.io/pithecene-io/quarry:slim
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 🐳 Build & push (full)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: full
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/pithecene-io/quarry:${{ steps.version.outputs.version }}
+            ghcr.io/pithecene-io/quarry:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Swap Docker image build order in the release workflow from full→slim to slim→full. Since `full` extends `slim` (`FROM slim AS full`), building slim first populates the GHA cache for all shared layers (Go build, Node deps, slim runtime). The full build then only adds the Chromium install layer on top.

## Highlights

- Invert build order: slim first, then full
- Full build reuses cached build/deps/slim layers instead of rebuilding from scratch
- CI `Dockerfile Check` job is unaffected (lint-only, no actual build)

## Test plan

- [ ] Verify next release build completes faster than previous (~halved wall time for shared layers)
- [ ] Verify both `:version` and `:version-slim` tags are pushed correctly to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)