### PR TITLE
fix(examples): 🐛 disable browser reuse in example runner

### DIFF
--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -132,6 +132,7 @@ async function runExample(example: Example): Promise<RunResult> {
     "--run-id", runId,
     "--source", "example-runner",
     "--category", "examples",
+    "--no-browser-reuse",
     "--executor", EXECUTOR_BIN,
     "--storage-backend", "fs",
     "--storage-path", storagePath,


### PR DESCRIPTION
## Summary
Disable browser reuse for example runs to avoid intermittent exit-code mismatches in the CI intentional-failure check.

## Highlights
- add --no-browser-reuse to example runner invocations in scripts/run-examples.ts
- keep strict exit-code assertion in examples/manifest.json unchanged

## Test plan
- [ ] task examples (blocked in local sandbox by tsx IPC EPERM)
- [ ] CI (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)