### PR TITLE
chore: 🔖 bump lockstep version to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [0.7.2] - 2026-02-11
+
 ### Changed
 
 - **Container**: Full image uses Chrome for Testing tarball instead of distro Chromium — pins browser version to puppeteer compatibility matrix (#159)
@@ -16,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Container**: Retain `ca-certificates` in full runtime image — previous purge of build-time download tools accidentally removed the TLS trust store, breaking HTTPS at runtime (#159)
-- **Container**: Add `libasound2` to Chrome shared-library set — missing ALSA dependency could cause Chrome to fail at dynamic link time (#159)
-- **Container**: Fail fast when building full image on non-amd64 — prevents silent production of images with a wrong-architecture Chrome binary (#159)
+- **IPC**: Protect IPC channel from stray stdout writes — third-party code (puppeteer-extra, stealth plugin) writing to `process.stdout` caused the Go `FrameDecoder` to interpret text as a length prefix, deriving huge payload sizes and blocking indefinitely; stdout guard now captures the real `write` for IPC and redirects stray writes to stderr with a diagnostic warning (#161)
+- **Container**: Retain `ca-certificates` in full runtime image — previous purge of build-time download tools accidentally removed the TLS trust store, breaking HTTPS at runtime (#160)
+- **Container**: Add `libasound2` to Chrome shared-library set — missing ALSA dependency could cause Chrome to fail at dynamic link time (#160)
+- **Container**: Fail fast when building full image on non-amd64 — prevents silent production of images with a wrong-architecture Chrome binary (#160)
 
 ---
 
@@ -386,6 +393,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.7.2]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.2
 [0.7.1]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.1
 [0.7.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.0
 [0.6.3]: https://github.com/pithecene-io/quarry/releases/tag/v0.6.3

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.7.1.
+User-facing guide for Quarry v0.7.2.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,24 +26,24 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:pithecene-io/quarry@0.7.1
+mise install github:pithecene-io/quarry@0.7.2
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:pithecene-io/quarry" = "0.7.1"
+"github:pithecene-io/quarry" = "0.7.2"
 ```
 
 ### Via Docker
 
 ```bash
 # Full image — includes Chrome for Testing + fonts (amd64 only, recommended)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1
+docker pull ghcr.io/pithecene-io/quarry:0.7.2
 
 # Slim image — no browser, multi-arch (BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for `docker run` and Docker Compose examples.
@@ -439,14 +439,14 @@ task build
 
 Quarry ships container images via GHCR:
 
-- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.7.1` — includes Chrome for Testing + fonts
-- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.7.1-slim` — no browser (BYO via `--browser-ws-endpoint`)
+- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.7.2` — includes Chrome for Testing + fonts
+- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.7.2-slim` — no browser (BYO via `--browser-ws-endpoint`)
 
 For `docker run`, Docker Compose, and sidecar patterns, see [docs/guides/container.md](docs/guides/container.md).
 
 ---
 
-## Known Limitations (v0.7.1)
+## Known Limitations (v0.7.2)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -531,7 +531,7 @@ See adapter flags above.
 
 ```bash
 quarry version
-# 0.7.1 (commit: ...)
+# 0.7.2 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -540,8 +540,8 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.7.1` |
-| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.1` |
-| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.1-slim` |
+| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.7.2` |
+| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.2` |
+| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim` |
 | SDK | JSR | `npx jsr add @pithecene-io/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @pithecene-io/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -15,27 +15,27 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:pithecene-io/quarry@0.7.1
+mise install github:pithecene-io/quarry@0.7.2
 ```
 
 ### Docker
 
 ```bash
 # Full image (includes Chromium + fonts)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1
+docker pull ghcr.io/pithecene-io/quarry:0.7.2
 
 # Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
 ```
 
 ### Docker
 
 ```bash
 # Full image (includes Chromium + fonts)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1
+docker pull ghcr.io/pithecene-io/quarry:0.7.2
 
 # Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.1-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for Docker Compose examples.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.7.1
+# Support Posture — Quarry v0.7.2
 
-This document defines support expectations for Quarry v0.7.1.
+This document defines support expectations for Quarry v0.7.2.
 
 ---
 
 ## Maturity Level
 
-**v0.7.1 is an early release.** APIs and behaviors may change in subsequent
+**v0.7.2 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.7.1._
+_No known issues in v0.7.2._
 
 ---
 
@@ -136,5 +136,5 @@ quarry version
 
 ## No Warranty
 
-Quarry v0.7.1 is provided "as is" without warranty of any kind.
+Quarry v0.7.2 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/contracts/CONTRACT_CLI.md
+++ b/docs/contracts/CONTRACT_CLI.md
@@ -244,7 +244,7 @@ config file providing project-level defaults for run flags.
 **No auto-discovery:** Config files are loaded only via explicit `--config`.
 There is no implicit `quarry.yaml` search in the working directory.
 
-### Transparent Browser Reuse (v0.7.1+)
+### Transparent Browser Reuse (v0.7.2+)
 
 By default, `quarry run` transparently reuses a Chromium browser process
 across sequential invocations. The browser is launched as a detached process

--- a/docs/guides/container.md
+++ b/docs/guides/container.md
@@ -11,8 +11,8 @@ Quarry ships two container images via GHCR:
 
 | Image | Tag | Arch | Includes |
 |-------|-----|------|----------|
-| Full | `ghcr.io/pithecene-io/quarry:0.7.1` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
-| Slim | `ghcr.io/pithecene-io/quarry:0.7.1-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
+| Full | `ghcr.io/pithecene-io/quarry:0.7.2` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
+| Slim | `ghcr.io/pithecene-io/quarry:0.7.2-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
 
 The **full** image is recommended for standalone usage. The **slim** image is
 for environments where Chromium is provided externally (e.g., via
@@ -34,7 +34,7 @@ and run as a non-root `quarry` user.
 docker run --rm \
   -v ./scripts:/work/scripts:ro \
   -v ./data:/work/data \
-  ghcr.io/pithecene-io/quarry:0.7.1 \
+  ghcr.io/pithecene-io/quarry:0.7.2 \
   run \
     --script ./scripts/my-script.ts \
     --run-id "run-$(date +%s)" \
@@ -50,7 +50,7 @@ docker run --rm \
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.1
+    image: ghcr.io/pithecene-io/quarry:0.7.2
     volumes:
       - ./scripts:/work/scripts:ro
       - ./data:/work/data
@@ -71,7 +71,7 @@ services:
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.1
+    image: ghcr.io/pithecene-io/quarry:0.7.2
     volumes:
       - ./scripts:/work/scripts:ro
     environment:
@@ -99,7 +99,7 @@ services:
       - "6379:6379"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.1
+    image: ghcr.io/pithecene-io/quarry:0.7.2
     depends_on:
       - redis
     volumes:
@@ -136,7 +136,7 @@ services:
       - "9222:9222"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.1-slim
+    image: ghcr.io/pithecene-io/quarry:0.7.2-slim
     depends_on:
       - chrome
     volumes:

--- a/executor-node/test/ipc/fixtures/drain-stdout-child.ts
+++ b/executor-node/test/ipc/fixtures/drain-stdout-child.ts
@@ -12,7 +12,7 @@ const sink = new StdioSink(process.stdout)
 
 // Item event
 await sink.writeEvent({
-  contract_version: '0.7.1',
+  contract_version: '0.7.2',
   event_id: 'evt-1' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 1,
@@ -24,7 +24,7 @@ await sink.writeEvent({
 
 // Terminal event (run_complete)
 await sink.writeEvent({
-  contract_version: '0.7.1',
+  contract_version: '0.7.2',
   event_id: 'evt-2' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 2,

--- a/executor-node/test/ipc/fixtures/stdout-guard-child.ts
+++ b/executor-node/test/ipc/fixtures/stdout-guard-child.ts
@@ -16,7 +16,7 @@ const sink = new StdioSink(ipcOutput)
 
 // First IPC frame
 await sink.writeEvent({
-  contract_version: '0.7.1',
+  contract_version: '0.7.2',
   event_id: 'evt-1' as EventId,
   run_id: 'run-guard-test' as RunId,
   seq: 1,
@@ -31,7 +31,7 @@ process.stdout.write('Browser started successfully\n')
 
 // Second IPC frame
 await sink.writeEvent({
-  contract_version: '0.7.1',
+  contract_version: '0.7.2',
   event_id: 'evt-2' as EventId,
   run_id: 'run-guard-test' as RunId,
   seq: 2,

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.7.1
+// Quarry Executor Bundle v0.7.2
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.7.1";
+    CONTRACT_VERSION = "0.7.2";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/policy/benchmark_test.go
+++ b/quarry/policy/benchmark_test.go
@@ -16,7 +16,7 @@ import (
 // benchEnvelope returns a realistic event envelope for benchmarks.
 func benchEnvelope(seq int64) *types.EventEnvelope {
 	return &types.EventEnvelope{
-		ContractVersion: "0.7.1",
+		ContractVersion: "0.7.2",
 		EventID:         fmt.Sprintf("evt-%d", seq),
 		RunID:           "bench-run-001",
 		Seq:             seq,
@@ -232,7 +232,7 @@ func BenchmarkBufferedPolicy_DropPressure(b *testing.B) {
 
 	// Droppable event that will be dropped on each iteration
 	droppable := &types.EventEnvelope{
-		ContractVersion: "0.7.1",
+		ContractVersion: "0.7.2",
 		EventID:         "drop-001",
 		RunID:           "bench-run-001",
 		Seq:             100,

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.7.1"
+const Version = "0.7.2"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.7.1' as const
+export const CONTRACT_VERSION = '0.7.2' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.7.1",
+    "contract_version": "0.7.2",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Lockstep version bump from 0.7.1 → 0.7.2 covering the IPC stdout guard fix (#161), container runtime regressions (#160), and Chrome for Testing switch (#159).

## Highlights

- **Version files**: `types/version.go`, `sdk/package.json`, `sdk/src/types/events.ts` `CONTRACT_VERSION` → 0.7.2
- **Golden fixtures**: `sdk/test/emit/06-golden/*.json` `contract_version` → 0.7.2
- **Test fixtures**: executor-node IPC fixtures, Go benchmark fixtures → 0.7.2
- **Rebuilt artifacts**: SDK (`tsdown`) and executor bundle (`task executor:bundle`)
- **Changelog**: promoted `[Unreleased]` → `[0.7.2] - 2026-02-11` with #161, #160, #159 entries
- **Docs**: PUBLIC_API.md, README.md, SUPPORT.md, container.md, CONTRACT_CLI.md version refs updated

## Test plan

- [x] `pnpm -C sdk test` — 176 tests pass
- [x] `pnpm -C executor-node test` — 121 tests pass (includes stdout-guard fixtures)
- [x] `go test ./...` — all Go tests pass (includes benchmark fixture)
- [x] No stale 0.7.1 references outside CHANGELOG history
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)