### PR TITLE
chore: 🔖 bump lockstep version to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ _No unreleased changes._
 
 ---
 
+## [0.7.3] - 2026-02-12
+
+### Changed
+
+- **Lode**: Upgrade Lode storage library to v0.7.3
+
+### Fixed
+
+- **IPC**: Eliminate stdout guard proxy to fix drain deadlock — `Object.create(process.stdout)` caused `_events` divergence after listener cleanup, silently breaking drain delivery and hanging the executor under backpressure; replaced with split contract (separate stream + writeFn) (#164)
+
+### Added
+
+- **IPC**: Backpressure integration test that deterministically proves drain path is exercised — spawns child, withholds parent reads until pipe fills, asserts `backpressure_events > 0` (#164)
+- **AGENTS.md**: Stream & EventEmitter discipline guardrail — bans `Object.create()` on EventEmitter instances, requires composition over prototype delegation (#164)
+
+---
+
 ## [0.7.2] - 2026-02-11
 
 ### Changed
@@ -393,6 +410,7 @@ _No unreleased changes._
 
 ---
 
+[0.7.3]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.3
 [0.7.2]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.2
 [0.7.1]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.1
 [0.7.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.0

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,6 +1,6 @@
 # Quarry Public API
 
-User-facing guide for Quarry v0.7.2.
+User-facing guide for Quarry v0.7.3.
 Normative behavior is defined by contracts under `docs/contracts/`.
 
 ---
@@ -26,24 +26,24 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:pithecene-io/quarry@0.7.2
+mise install github:pithecene-io/quarry@0.7.3
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:pithecene-io/quarry" = "0.7.2"
+"github:pithecene-io/quarry" = "0.7.3"
 ```
 
 ### Via Docker
 
 ```bash
 # Full image — includes Chrome for Testing + fonts (amd64 only, recommended)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2
+docker pull ghcr.io/pithecene-io/quarry:0.7.3
 
 # Slim image — no browser, multi-arch (BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.3-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for `docker run` and Docker Compose examples.
@@ -439,14 +439,14 @@ task build
 
 Quarry ships container images via GHCR:
 
-- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.7.2` — includes Chrome for Testing + fonts
-- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.7.2-slim` — no browser (BYO via `--browser-ws-endpoint`)
+- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.7.3` — includes Chrome for Testing + fonts
+- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.7.3-slim` — no browser (BYO via `--browser-ws-endpoint`)
 
 For `docker run`, Docker Compose, and sidecar patterns, see [docs/guides/container.md](docs/guides/container.md).
 
 ---
 
-## Known Limitations (v0.7.2)
+## Known Limitations (v0.7.3)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -531,7 +531,7 @@ See adapter flags above.
 
 ```bash
 quarry version
-# 0.7.2 (commit: ...)
+# 0.7.3 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -540,8 +540,8 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.7.2` |
-| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.2` |
-| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim` |
+| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.7.3` |
+| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.3` |
+| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.7.3-slim` |
 | SDK | JSR | `npx jsr add @pithecene-io/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @pithecene-io/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -15,27 +15,27 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:pithecene-io/quarry@0.7.2
+mise install github:pithecene-io/quarry@0.7.3
 ```
 
 ### Docker
 
 ```bash
 # Full image (includes Chromium + fonts)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2
+docker pull ghcr.io/pithecene-io/quarry:0.7.3
 
 # Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.3-slim
 ```
 
 ### Docker
 
 ```bash
 # Full image (includes Chromium + fonts)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2
+docker pull ghcr.io/pithecene-io/quarry:0.7.3
 
 # Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.7.2-slim
+docker pull ghcr.io/pithecene-io/quarry:0.7.3-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for Docker Compose examples.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.7.2
+# Support Posture — Quarry v0.7.3
 
-This document defines support expectations for Quarry v0.7.2.
+This document defines support expectations for Quarry v0.7.3.
 
 ---
 
 ## Maturity Level
 
-**v0.7.2 is an early release.** APIs and behaviors may change in subsequent
+**v0.7.3 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.7.2._
+_No known issues in v0.7.3._
 
 ---
 
@@ -136,5 +136,5 @@ quarry version
 
 ## No Warranty
 
-Quarry v0.7.2 is provided "as is" without warranty of any kind.
+Quarry v0.7.3 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/guides/container.md
+++ b/docs/guides/container.md
@@ -11,8 +11,8 @@ Quarry ships two container images via GHCR:
 
 | Image | Tag | Arch | Includes |
 |-------|-----|------|----------|
-| Full | `ghcr.io/pithecene-io/quarry:0.7.2` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
-| Slim | `ghcr.io/pithecene-io/quarry:0.7.2-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
+| Full | `ghcr.io/pithecene-io/quarry:0.7.3` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
+| Slim | `ghcr.io/pithecene-io/quarry:0.7.3-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
 
 The **full** image is recommended for standalone usage. The **slim** image is
 for environments where Chromium is provided externally (e.g., via
@@ -34,7 +34,7 @@ and run as a non-root `quarry` user.
 docker run --rm \
   -v ./scripts:/work/scripts:ro \
   -v ./data:/work/data \
-  ghcr.io/pithecene-io/quarry:0.7.2 \
+  ghcr.io/pithecene-io/quarry:0.7.3 \
   run \
     --script ./scripts/my-script.ts \
     --run-id "run-$(date +%s)" \
@@ -50,7 +50,7 @@ docker run --rm \
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.2
+    image: ghcr.io/pithecene-io/quarry:0.7.3
     volumes:
       - ./scripts:/work/scripts:ro
       - ./data:/work/data
@@ -71,7 +71,7 @@ services:
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.2
+    image: ghcr.io/pithecene-io/quarry:0.7.3
     volumes:
       - ./scripts:/work/scripts:ro
     environment:
@@ -99,7 +99,7 @@ services:
       - "6379:6379"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.2
+    image: ghcr.io/pithecene-io/quarry:0.7.3
     depends_on:
       - redis
     volumes:
@@ -136,7 +136,7 @@ services:
       - "9222:9222"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.7.2-slim
+    image: ghcr.io/pithecene-io/quarry:0.7.3-slim
     depends_on:
       - chrome
     volumes:

--- a/executor-node/test/ipc/fixtures/backpressure-child.ts
+++ b/executor-node/test/ipc/fixtures/backpressure-child.ts
@@ -51,7 +51,7 @@ const FRAME_COUNT = 50
 
 for (let i = 1; i <= FRAME_COUNT; i++) {
   await sink.writeEvent({
-    contract_version: '0.7.2',
+    contract_version: '0.7.3',
     event_id: `evt-${i}` as EventId,
     run_id: 'run-bp-test' as RunId,
     seq: i,
@@ -67,7 +67,7 @@ process.stdout.write('stray write during backpressure\n')
 
 // Terminal event
 await sink.writeEvent({
-  contract_version: '0.7.2',
+  contract_version: '0.7.3',
   event_id: `evt-${FRAME_COUNT + 1}` as EventId,
   run_id: 'run-bp-test' as RunId,
   seq: FRAME_COUNT + 1,

--- a/executor-node/test/ipc/fixtures/drain-stdout-child.ts
+++ b/executor-node/test/ipc/fixtures/drain-stdout-child.ts
@@ -12,7 +12,7 @@ const sink = new StdioSink(process.stdout)
 
 // Item event
 await sink.writeEvent({
-  contract_version: '0.7.2',
+  contract_version: '0.7.3',
   event_id: 'evt-1' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 1,
@@ -24,7 +24,7 @@ await sink.writeEvent({
 
 // Terminal event (run_complete)
 await sink.writeEvent({
-  contract_version: '0.7.2',
+  contract_version: '0.7.3',
   event_id: 'evt-2' as EventId,
   run_id: 'run-drain-test' as RunId,
   seq: 2,

--- a/executor-node/test/ipc/fixtures/stdout-guard-child.ts
+++ b/executor-node/test/ipc/fixtures/stdout-guard-child.ts
@@ -17,7 +17,7 @@ const sink = new StdioSink(ipcOutput, ipcWrite)
 
 // First IPC frame
 await sink.writeEvent({
-  contract_version: '0.7.2',
+  contract_version: '0.7.3',
   event_id: 'evt-1' as EventId,
   run_id: 'run-guard-test' as RunId,
   seq: 1,
@@ -32,7 +32,7 @@ process.stdout.write('Browser started successfully\n')
 
 // Second IPC frame
 await sink.writeEvent({
-  contract_version: '0.7.2',
+  contract_version: '0.7.3',
   event_id: 'evt-2' as EventId,
   run_id: 'run-guard-test' as RunId,
   seq: 2,

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.7.2
+// Quarry Executor Bundle v0.7.3
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.7.2";
+    CONTRACT_VERSION = "0.7.3";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/go.mod
+++ b/quarry/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
-	github.com/pithecene-io/lode v0.7.2
+	github.com/pithecene-io/lode v0.7.3
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/quarry/go.sum
+++ b/quarry/go.sum
@@ -121,8 +121,8 @@ github.com/parquet-go/parquet-go v0.27.0 h1:vHWK2xaHbj+v1DYps03yDRpEsdtOeKbhiXUa
 github.com/parquet-go/parquet-go v0.27.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
 github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
-github.com/pithecene-io/lode v0.7.2 h1:VFuBlG2MN1rC+4Sh4CK44XprMnRM/ca8OcT1IvosK0Q=
-github.com/pithecene-io/lode v0.7.2/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
+github.com/pithecene-io/lode v0.7.3 h1:raZLfdIrWhFpZTi4y+O1WsqmiW/ycY6KT6BK9g4ExSo=
+github.com/pithecene-io/lode v0.7.3/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.17.3 h1:fN29NdNrE17KttK5Ndf20buqfDZwGNgoUr9qjl1DQx4=

--- a/quarry/lode/client_failure_test.go
+++ b/quarry/lode/client_failure_test.go
@@ -39,7 +39,13 @@ func (s *FailingStore) Put(_ context.Context, path string, _ io.Reader) error {
 }
 
 func (s *FailingStore) Get(_ context.Context, _ string) (io.ReadCloser, error) {
-	return nil, s.GetErr
+	if s.GetErr != nil {
+		return nil, s.GetErr
+	}
+	// FailingStore never stores data; return not-found so callers
+	// (e.g. Lode's readLatestPointer) handle the absence gracefully
+	// instead of receiving a nil reader with a nil error.
+	return nil, os.ErrNotExist
 }
 
 func (s *FailingStore) Exists(_ context.Context, _ string) (bool, error) {

--- a/quarry/policy/benchmark_test.go
+++ b/quarry/policy/benchmark_test.go
@@ -16,7 +16,7 @@ import (
 // benchEnvelope returns a realistic event envelope for benchmarks.
 func benchEnvelope(seq int64) *types.EventEnvelope {
 	return &types.EventEnvelope{
-		ContractVersion: "0.7.2",
+		ContractVersion: "0.7.3",
 		EventID:         fmt.Sprintf("evt-%d", seq),
 		RunID:           "bench-run-001",
 		Seq:             seq,
@@ -232,7 +232,7 @@ func BenchmarkBufferedPolicy_DropPressure(b *testing.B) {
 
 	// Droppable event that will be dropped on each iteration
 	droppable := &types.EventEnvelope{
-		ContractVersion: "0.7.2",
+		ContractVersion: "0.7.3",
 		EventID:         "drop-001",
 		RunID:           "bench-run-001",
 		Seq:             100,

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.7.2"
+const Version = "0.7.3"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.7.2' as const
+export const CONTRACT_VERSION = '0.7.3' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.7.2",
+    "contract_version": "0.7.3",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Upgrade Lode to v0.7.3 and bump all lockstep version references from 0.7.2 → 0.7.3 across canonical sources, golden fixtures, IPC test fixtures, benchmark data, documentation, and bundles.

## Highlights

- Upgrade `github.com/pithecene-io/lode` v0.7.2 → v0.7.3
- Bump canonical version in `types/version.go`, `sdk/package.json`, `sdk/src/types/events.ts`
- Update golden test fixtures and IPC test fixture contract versions
- Fix `FailingStore.Get` in lode client tests — return `os.ErrNotExist` instead of `(nil, nil)` to match Lode v0.7.3 pointer resolution behavior
- Rebuild SDK dist and executor bundle
- Promote CHANGELOG.md with 0.7.3 section

## Test plan

- [x] Go builds (`go build ./...`)
- [x] Go tests pass (`go test ./...`) — 17 packages, including lode client failure tests
- [x] SDK tests pass (176/176)
- [x] Executor tests pass (124/124)
- [x] Bundle version audit — 0 occurrences of `0.7.2` in `executor.mjs`
- [x] Stale version sweep — 0 occurrences of `0.7.2` outside `go.sum` and `CHANGELOG.md`
- [x] Golden fixtures — all `contract_version` fields = `"0.7.3"`
- [x] Changelog structure — `[Unreleased]` placeholder present, `[0.7.3]` dated, link added

🤖 Generated with [Claude Code](https://claude.com/claude-code)