### PR TITLE
chore(deps): ⬆️ upgrade Lode to v0.7.4

### DIFF
--- a/quarry/go.mod
+++ b/quarry/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
-	github.com/pithecene-io/lode v0.7.3
+	github.com/pithecene-io/lode v0.7.4
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/quarry/go.sum
+++ b/quarry/go.sum
@@ -121,8 +121,8 @@ github.com/parquet-go/parquet-go v0.27.0 h1:vHWK2xaHbj+v1DYps03yDRpEsdtOeKbhiXUa
 github.com/parquet-go/parquet-go v0.27.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
 github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
-github.com/pithecene-io/lode v0.7.3 h1:raZLfdIrWhFpZTi4y+O1WsqmiW/ycY6KT6BK9g4ExSo=
-github.com/pithecene-io/lode v0.7.3/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
+github.com/pithecene-io/lode v0.7.4 h1:r2QW14BUHmn927WCyGhmQlpynaGxTZSb978O3m4Ac2A=
+github.com/pithecene-io/lode v0.7.4/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.17.3 h1:fN29NdNrE17KttK5Ndf20buqfDZwGNgoUr9qjl1DQx4=


### PR DESCRIPTION
## Summary

Upgrade Lode storage library from v0.7.3 → v0.7.4 to pick up additional performance improvements before the v0.7.3 Quarry release.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass (including lode client failure tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)