### PR TITLE
ci(release): 👷 add container build to release dry-run

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -170,3 +170,34 @@ jobs:
           name: dry-run-dist
           path: dist/
           retention-days: 7
+
+  container:
+    name: 🐳 Container Images (Dry Run)
+    runs-on: ubuntu-latest
+    needs: [version_lockstep, lint, test, build, examples]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🐳 Build slim (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: slim
+          push: false
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 🐳 Build full (no push, amd64 only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: full
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Add container image builds (slim + full) to the release dry-run workflow so Dockerfile changes are validated before tagging.

## Highlights

- Builds both slim (amd64 + arm64) and full (amd64 only) targets with `push: false`
- Uses GHA cache (`cache-from`/`cache-to`) matching the real release workflow
- No GHCR login needed since images aren't pushed
- Runs in parallel with the package job after all gates pass

## Test plan

- [ ] CI passes
- [ ] Trigger release dry-run after merge to verify container builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)