### PR TITLE
docs(sdk): 📝 document createBatcher and clean up ARCH_INDEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- **SDK**: `createBatcher` utility for batching `emit.enqueue()` calls — accumulates items and emits fewer, larger enqueue events with `params.items`, reducing child run count for high fan-out workloads (#170)
+
+### Changed
+
+- **Container**: Go module layer split and multi-stage cache mounts for faster image builds (#167)
+- **CI**: Container build added to release dry-run workflow (#168)
 
 ---
 

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -67,17 +67,7 @@ Node-based executor implementation and IPC boundary.
 
 - `executor.ts` — core executor logic
 - `bin/executor.ts` — CLI entrypoint
-- `loader.ts` — runtime/bootstrap concerns
-- `index.ts` — package entrypoint
-
-#### executor-node/src/ipc/
-
-IPC implementation details for the executor side.
-
-- `frame.ts` — low-level frame encoding/decoding
-- `sink.ts` — IPC sink abstraction
-- `observing-sink.ts` — instrumentation/observation wrapper
-- `index.ts` — local entrypoint
+- `ipc/` — IPC framing, sink abstraction, and instrumentation
 
 ### executor-node/test/
 
@@ -93,14 +83,9 @@ Defines **stable APIs** for emitting events, artifacts, and lifecycle signals.
 ### sdk/src/
 
 - `emit.ts` — public emit API
-- `emit-impl.ts` — internal implementation
 - `context.ts` — execution context model
 - `hooks.ts` — lifecycle hooks
-- `index.ts` — SDK public entrypoint
-
-#### sdk/src/types/
-
-Shared domain types exposed by the SDK.
+- `types/` — shared domain types exposed by the SDK
 
 ### sdk/test/
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -102,6 +102,31 @@ Sidecar file upload interface available via `ctx.storage`.
 Files land under the run's `files/` prefix. Use `emit.artifact()` for larger
 payloads or when chunk-level progress tracking is needed.
 
+### createBatcher
+
+Accumulates items and emits batched enqueue events, reducing child run count
+for high fan-out workloads.
+
+```typescript
+import { createBatcher } from '@pithecene-io/quarry-sdk'
+
+const batcher = createBatcher<{ url: string }>(ctx.emit, {
+  size: 50,
+  target: 'detail.ts',
+})
+
+await batcher.add({ url })   // auto-flushes every 50 items
+await batcher.flush()         // emit remaining items
+console.log(batcher.pending)  // 0
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `size` | `number` | Items per batch (positive integer, required) |
+| `target` | `string` | Enqueue target script (required) |
+| `source` | `string?` | Partition override |
+| `category` | `string?` | Partition override |
+
 ### Lifecycle Hooks
 
 Export these from your script module for lifecycle control:


### PR DESCRIPTION
## Summary

Documents the new `createBatcher` SDK utility (#170) across user-facing docs and populates the changelog with all commits since v0.7.3. Also trims ARCH_INDEX.md down to subsystem-level orientation by removing per-file listings that duplicate what a file tree already shows.

## Highlights

- **CHANGELOG.md**: Populated `[Unreleased]` with #167 (container build caching), #168 (CI dry-run), #170 (createBatcher)
- **PUBLIC_API.md**: Added "Batching Enqueue Calls" subsection with usage example and constraints
- **sdk/README.md**: Added `createBatcher` API section with signature, example, and options table
- **docs/guides/emit.md**: Added "Batching for High Fan-Out" guidance under Advisory Events
- **docs/ARCH_INDEX.md**: Removed `index.ts` entrypoints, `emit-impl.ts`, `loader.ts`, individual IPC file listings, and `sdk/src/types/` sub-heading — collapsed to directory-level descriptions

## Test plan

- [x] No code changes — documentation only
- [ ] Visual review of markdown rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)