### PR TITLE
chore: 🔖 bump lockstep version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [0.8.0] - 2026-02-13
+
 ### Added
 
 - **SDK**: `createBatcher` utility for batching `emit.enqueue()` calls — accumulates items and emits fewer, larger enqueue events with `params.items`, reducing child run count for high fan-out workloads (#170)
@@ -417,6 +423,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.8.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.8.0
 [0.7.3]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.3
 [0.7.2]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.2
 [0.7.1]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.1

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.7.3
+// Quarry Executor Bundle v0.8.0
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.7.3";
+    CONTRACT_VERSION = "0.8.0";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.7.3"
+const Version = "0.8.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.7.3' as const
+export const CONTRACT_VERSION = '0.8.0' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.7.3",
+    "contract_version": "0.8.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Bump all lockstep version sources from 0.7.3 → 0.8.0 and promote the changelog.

## Highlights

- `quarry/types/version.go` → 0.8.0 (canonical)
- `sdk/package.json` → 0.8.0
- `sdk/src/types/events.ts` CONTRACT_VERSION → 0.8.0
- Golden test fixtures updated (2 files, 7 occurrences)
- Executor bundle rebuilt with new version
- `CHANGELOG.md` [Unreleased] promoted to [0.8.0] - 2026-02-13

## Test plan

- [ ] Version Lockstep CI check passes
- [ ] SDK tests pass (golden fixtures match)
- [ ] Bundle Freshness check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)