### PR TITLE
chore: 🔖 bump lockstep version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ _No unreleased changes._
 
 ---
 
+## [0.9.0] - 2026-02-13
+
+### Added
+
+- **SDK**: `prepare` lifecycle hook — transform or filter job payloads before browser launch; return `{ action: 'skip' }` to short-circuit a run without acquiring a browser (#175)
+- **SDK**: `beforeTerminal` lifecycle hook — outcome-aware hook that fires after script execution but before the terminal event, with emit still open; useful for emitting summary items or final metadata (#175)
+- **SDK**: `PrepareResult`, `PrepareHook`, `TerminalSignal`, `BeforeTerminalHook` type exports (#175)
+- **Executor**: Malformed `prepare` return validation — null, undefined, non-object, or missing `action` returns produce a diagnostic crash instead of an unhandled TypeError (#175)
+- **Docs**: Lifecycle hooks documented in PUBLIC_API.md, run guide, and emit guide (#175)
+- **Docs**: `CONTRACT_RUN.md` updated with lifecycle hook execution model and `prepare`-skip early return semantics
+- **Docs**: `CONTRACT_EMIT.md` updated with `skipped` and `reason` fields on `run_complete` summary
+- **Examples**: `hooks-prepare` and `hooks-before-terminal` runnable examples (#175)
+- **Testing**: 24 new executor tests and 7 loader validation tests for lifecycle hooks (#175)
+
+---
+
 ## [0.8.0] - 2026-02-13
 
 ### Added
@@ -423,6 +439,7 @@ _No unreleased changes._
 
 ---
 
+[0.9.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.9.0
 [0.8.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.8.0
 [0.7.3]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.3
 [0.7.2]: https://github.com/pithecene-io/quarry/releases/tag/v0.7.2

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.7.3
+# Support Posture — Quarry v0.9.0
 
-This document defines support expectations for Quarry v0.7.3.
+This document defines support expectations for Quarry v0.9.0.
 
 ---
 
 ## Maturity Level
 
-**v0.7.3 is an early release.** APIs and behaviors may change in subsequent
+**v0.9.0 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.7.3._
+_No known issues in v0.9.0._
 
 ---
 
@@ -30,6 +30,7 @@ _No known issues in v0.7.3._
 | Filesystem storage backend | Supported |
 | S3 storage backend | Supported |
 | SDK emit API | Supported |
+| Lifecycle hooks (`prepare`, `beforeTerminal`) | Supported |
 | Fan-out (`--depth`) | Experimental |
 
 ### Supported Platforms
@@ -136,5 +137,5 @@ quarry version
 
 ## No Warranty
 
-Quarry v0.7.3 is provided "as is" without warranty of any kind.
+Quarry v0.9.0 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/contracts/CONTRACT_EMIT.md
+++ b/docs/contracts/CONTRACT_EMIT.md
@@ -141,6 +141,17 @@ Represents normal completion of the script.
 Required payload fields:
 - `summary` (object, optional)
 
+#### Reserved summary fields (v0.9.0+)
+
+When the `prepare` hook returns `{ action: 'skip' }`, the executor emits
+`run_complete` with the following reserved fields in `summary`:
+
+- `skipped` (boolean) — `true` when the run was skipped by `prepare`
+- `reason` (string, optional) — skip reason provided by the hook
+
+Scripts should not use `skipped` or `reason` as summary keys for other
+purposes. These fields are set by the executor, not by user code.
+
 ---
 
 ## Storage API (`storage.put()`)

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.8.0
+// Quarry Executor Bundle v0.9.0
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -214,7 +214,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.8.0";
+    CONTRACT_VERSION = "0.9.0";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.8.0"
+const Version = "0.9.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.8.0' as const
+export const CONTRACT_VERSION = '0.9.0' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 // ============================================

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.8.0",
+    "contract_version": "0.9.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Bump all lockstep version sources to 0.9.0 and promote changelog. Adds contract coverage for the `prepare` and `beforeTerminal` lifecycle hooks introduced in #175.

## Highlights

- **Lockstep bump**: `version.go`, `package.json`, `CONTRACT_VERSION`, golden fixtures, executor bundle
- **CHANGELOG.md**: promote `[Unreleased]` → `[0.9.0]` with hooks feature entry
- **CONTRACT_RUN.md**: lifecycle hook execution model — `prepare`-skip semantics, `beforeTerminal` guarantees, hook contract rules
- **CONTRACT_EMIT.md**: reserved `skipped` and `reason` fields on `run_complete` summary
- **SUPPORT.md**: bump to v0.9.0, add lifecycle hooks to supported components table

## Test plan

- [x] SDK tests pass (208/208)
- [x] Executor tests pass (153/153)
- [x] Go tests pass
- [x] TypeScript type checks clean (SDK + executor)
- [x] Golden fixtures updated
- [x] Executor bundle rebuilt and version verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)