### PR TITLE
test(resolve-from): ✅ add end-to-end integration test for ESM resolve hook

### DIFF
--- a/executor-node/src/bin/executor.ts
+++ b/executor-node/src/bin/executor.ts
@@ -306,50 +306,8 @@ async function main(): Promise<never> {
   // so ESM import conditions (not CJS require conditions) are preserved.
   const resolveFrom = process.env.QUARRY_RESOLVE_FROM
   if (resolveFrom) {
-    const { register } = await import('node:module')
-    const hookCode = `
-      import { pathToFileURL } from 'node:url';
-
-      let fallbackParentURL;
-
-      export function initialize(data) {
-        // Construct a file:// URL pointing into the resolve-from directory.
-        // nextResolve uses parentURL as the resolution base, so ESM
-        // "imports" conditions are applied (not CJS "require" conditions).
-        fallbackParentURL = pathToFileURL(data.resolveFrom + '/noop.js').href;
-      }
-
-      export async function resolve(specifier, context, nextResolve) {
-        // Skip relative and absolute specifiers — only intercept bare specifiers
-        if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
-          return nextResolve(specifier, context);
-        }
-
-        // Try default resolution first
-        try {
-          return await nextResolve(specifier, context);
-        } catch (defaultErr) {
-          // Retry with parentURL pointing at --resolve-from directory.
-          // This preserves ESM import conditions (package.json "exports"
-          // with "import" key) unlike createRequire().resolve().
-          try {
-            const result = await nextResolve(specifier, {
-              ...context,
-              parentURL: fallbackParentURL,
-            });
-            process.stderr.write(
-              'quarry: resolved "' + specifier + '" via --resolve-from fallback\\n'
-            );
-            return result;
-          } catch {
-            // Re-throw the original error if fallback also fails
-            throw defaultErr;
-          }
-        }
-      }
-    `
-    const hookUrl = `data:text/javascript;base64,${Buffer.from(hookCode).toString('base64')}`
-    register(hookUrl, { data: { resolveFrom } })
+    const { registerResolveFromHook } = await import('../resolve-from.js')
+    await registerResolveFromHook(resolveFrom)
   }
 
   const scriptPath = args[0]

--- a/executor-node/src/resolve-from.ts
+++ b/executor-node/src/resolve-from.ts
@@ -1,0 +1,70 @@
+/**
+ * ESM resolve hook for --resolve-from support.
+ *
+ * Registers a module.register() hook that retries bare-specifier resolution
+ * with a fallback parentURL pointing at the --resolve-from directory.
+ * This preserves ESM import conditions (not CJS require conditions).
+ *
+ * @module
+ */
+
+/**
+ * The ESM loader hook source code, registered via data URL.
+ *
+ * Exported so integration tests can use the same hook code as production,
+ * preventing copy drift.
+ */
+export const resolveFromHookCode = `
+  import { pathToFileURL } from 'node:url';
+
+  let fallbackParentURL;
+
+  export function initialize(data) {
+    // Construct a file:// URL pointing into the resolve-from directory.
+    // nextResolve uses parentURL as the resolution base, so ESM
+    // "imports" conditions are applied (not CJS "require" conditions).
+    fallbackParentURL = pathToFileURL(data.resolveFrom + '/noop.js').href;
+  }
+
+  export async function resolve(specifier, context, nextResolve) {
+    // Skip relative and absolute specifiers — only intercept bare specifiers
+    if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
+      return nextResolve(specifier, context);
+    }
+
+    // Try default resolution first
+    try {
+      return await nextResolve(specifier, context);
+    } catch (defaultErr) {
+      // Retry with parentURL pointing at --resolve-from directory.
+      // This preserves ESM import conditions (package.json "exports"
+      // with "import" key) unlike CJS require-based resolution.
+      try {
+        const result = await nextResolve(specifier, {
+          ...context,
+          parentURL: fallbackParentURL,
+        });
+        process.stderr.write(
+          'quarry: resolved "' + specifier + '" via --resolve-from fallback\\n'
+        );
+        return result;
+      } catch {
+        // Re-throw the original error if fallback also fails
+        throw defaultErr;
+      }
+    }
+  }
+`
+
+/**
+ * Register the ESM resolve-from hook via module.register().
+ *
+ * The hook tries default resolution first, then falls back to resolving
+ * bare specifiers from the given directory using nextResolve with a
+ * substituted parentURL.
+ */
+export async function registerResolveFromHook(resolveFrom: string): Promise<void> {
+  const { register } = await import('node:module')
+  const hookUrl = `data:text/javascript;base64,${Buffer.from(resolveFromHookCode).toString('base64')}`
+  register(hookUrl, { data: { resolveFrom } })
+}

--- a/executor-node/test/resolve-from-hook.test.ts
+++ b/executor-node/test/resolve-from-hook.test.ts
@@ -1,58 +1,20 @@
 /**
  * Tests for the --resolve-from ESM resolve hook.
  *
- * The hook is embedded as a template string in bin/executor.ts and registered
- * via module.register() with a data URL. These tests validate:
- * - The hook code is syntactically valid JavaScript
- * - The hook exports the required initialize() and resolve() functions
- * - The resolve function skips relative/absolute/file: specifiers
+ * Imports the hook code from the production module (src/resolve-from.ts)
+ * and validates its structure. These tests catch:
+ * - Missing required exports (initialize, resolve)
+ * - Incorrect specifier guard clauses
+ * - Regression to CJS createRequire (vs ESM parentURL)
+ * - Missing observability (stderr logging)
+ * - Data URL encoding correctness
  */
 import { describe, expect, it } from 'vitest'
-
-/**
- * The hook code template, extracted from bin/executor.ts for testability.
- * This must be kept in sync with the source. A mismatch will be caught
- * by integration tests or the bundle build.
- */
-const hookCode = `
-  import { pathToFileURL } from 'node:url';
-
-  let fallbackParentURL;
-
-  export function initialize(data) {
-    fallbackParentURL = pathToFileURL(data.resolveFrom + '/noop.js').href;
-  }
-
-  export async function resolve(specifier, context, nextResolve) {
-    if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
-      return nextResolve(specifier, context);
-    }
-
-    try {
-      return await nextResolve(specifier, context);
-    } catch (defaultErr) {
-      try {
-        const result = await nextResolve(specifier, {
-          ...context,
-          parentURL: fallbackParentURL,
-        });
-        process.stderr.write(
-          'quarry: resolved "' + specifier + '" via --resolve-from fallback\\n'
-        );
-        return result;
-      } catch {
-        throw defaultErr;
-      }
-    }
-  }
-`
+import { resolveFromHookCode } from '../src/resolve-from.js'
 
 describe('resolve-from hook', () => {
   it('hook code can be encoded as a valid data URL module', () => {
-    // The hook uses ESM import/export syntax which can't be validated via
-    // new Function(). Instead, verify the data URL construction succeeds
-    // and produces a well-formed URL that module.register() would accept.
-    const encoded = Buffer.from(hookCode).toString('base64')
+    const encoded = Buffer.from(resolveFromHookCode).toString('base64')
     const dataUrl = `data:text/javascript;base64,${encoded}`
 
     // Must be a valid URL
@@ -67,42 +29,45 @@ describe('resolve-from hook', () => {
   })
 
   it('hook code exports initialize function', () => {
-    expect(hookCode).toContain('export function initialize(data)')
+    expect(resolveFromHookCode).toContain('export function initialize(data)')
   })
 
   it('hook code exports resolve function', () => {
-    expect(hookCode).toContain('export async function resolve(specifier, context, nextResolve)')
+    expect(resolveFromHookCode).toContain(
+      'export async function resolve(specifier, context, nextResolve)'
+    )
   })
 
   it('hook skips relative specifiers (. prefix)', () => {
-    // Verify the guard clause is present
-    expect(hookCode).toContain("specifier.startsWith('.')")
+    expect(resolveFromHookCode).toContain("specifier.startsWith('.')")
   })
 
   it('hook skips absolute specifiers (/ prefix)', () => {
-    expect(hookCode).toContain("specifier.startsWith('/')")
+    expect(resolveFromHookCode).toContain("specifier.startsWith('/')")
   })
 
   it('hook skips file: URL specifiers', () => {
-    expect(hookCode).toContain("specifier.startsWith('file:')")
+    expect(resolveFromHookCode).toContain("specifier.startsWith('file:')")
   })
 
   it('hook uses parentURL for fallback (not createRequire)', () => {
-    // Verify the fix: using nextResolve with parentURL preserves ESM
-    // import conditions, unlike createRequire().resolve() which uses
-    // CJS require conditions.
-    expect(hookCode).toContain('parentURL: fallbackParentURL')
-    expect(hookCode).not.toContain('createRequire')
+    // The hook should use nextResolve with parentURL (ESM conditions),
+    // not createRequire().resolve() (CJS conditions).
+    // The string "createRequire" may appear in comments; check that
+    // it's not imported or called as code.
+    expect(resolveFromHookCode).toContain('parentURL: fallbackParentURL')
+    expect(resolveFromHookCode).not.toMatch(/import.*createRequire/)
+    expect(resolveFromHookCode).not.toMatch(/createRequire\(/)
   })
 
   it('hook logs to stderr on fallback resolution', () => {
-    expect(hookCode).toContain('process.stderr.write')
-    expect(hookCode).toContain('--resolve-from fallback')
+    expect(resolveFromHookCode).toContain('process.stderr.write')
+    expect(resolveFromHookCode).toContain('--resolve-from fallback')
   })
 
   it('data URL construction produces valid base64', () => {
-    const encoded = Buffer.from(hookCode).toString('base64')
+    const encoded = Buffer.from(resolveFromHookCode).toString('base64')
     const decoded = Buffer.from(encoded, 'base64').toString()
-    expect(decoded).toBe(hookCode)
+    expect(decoded).toBe(resolveFromHookCode)
   })
 })

--- a/executor-node/test/resolve-from.integration.test.ts
+++ b/executor-node/test/resolve-from.integration.test.ts
@@ -10,8 +10,9 @@
  * - Without QUARRY_RESOLVE_FROM, the import fails (control case)
  */
 import { type ChildProcess, spawn } from 'node:child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -19,12 +20,12 @@ const testDir = dirname(fileURLToPath(import.meta.url))
 const fixturePath = resolve(testDir, 'fixtures/resolve-from-child.ts')
 const tsxBin = resolve(testDir, '../../node_modules/.bin/tsx')
 
-/** Temp directory for the fake node_modules tree. */
+/** Temp directory for the fake node_modules tree (unique per run). */
 let tmpDir: string
 
 beforeAll(() => {
-  // Create a temporary directory with a fake scoped package
-  tmpDir = join(testDir, '.tmp-resolve-from-test')
+  // Create a unique temporary directory to avoid cross-run interference
+  tmpDir = mkdtempSync(join(tmpdir(), 'quarry-resolve-from-test-'))
   const pkgDir = join(tmpDir, 'node_modules', '@test', 'greet')
   mkdirSync(pkgDir, { recursive: true })
 


### PR DESCRIPTION
## Summary

Add a behavioral integration test for the `--resolve-from` ESM resolve hook that exercises `module.register()` end-to-end with real module resolution — closing the gap identified in PR #178 review where existing tests were structure-based rather than runtime behavioral.

## Highlights

- Creates a temp `node_modules` with a fake scoped ESM package (`@test/greet`) that has **conditional exports** (`"import"` → `index.mjs`, `"require"` → `index.cjs` with deliberately different return values)
- Spawns a child process with `QUARRY_RESOLVE_FROM` set, registers the hook via `module.register()`, and dynamically imports the bare specifier
- **Asserts ESM import conditions are used**: gets `"hello from esm"` (not `"hello from cjs"`), confirming the `parentURL` fix from #178
- **Control cases**: missing env var → exit 2, wrong directory → exit 1
- Notes that the stderr fallback message from the loader thread may not flush before `process.exit()` (best-effort observability; behavioral assertion is authoritative)

## Test plan

- [x] `pnpm exec vitest run` in executor-node/ — all 166 tests pass (11 test files)
- [x] New integration test runs in <1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)