### PR TITLE
fix(executor): 🐛 prevent Chrome crashes from /dev/shm exhaustion and transient health failures

### DIFF
--- a/executor-node/src/browser-args.ts
+++ b/executor-node/src/browser-args.ts
@@ -1,0 +1,11 @@
+/**
+ * Build Chromium launch arguments.
+ * Always includes --disable-dev-shm-usage; conditionally adds sandbox flags.
+ */
+export function chromiumArgs(extra: string[] = []): string[] {
+  const args = ['--disable-dev-shm-usage', ...extra]
+  if (process.env.QUARRY_NO_SANDBOX === '1') {
+    args.push('--no-sandbox', '--disable-setuid-sandbox')
+  }
+  return args
+}

--- a/executor-node/src/browser-idle.ts
+++ b/executor-node/src/browser-idle.ts
@@ -1,0 +1,54 @@
+/** State tracked between idle-monitor poll ticks. */
+export type IdlePollState = {
+  idleStartedAt: number | null
+  consecutiveFailures: number
+}
+
+/** What the caller should do after evaluating a poll tick. */
+export type IdlePollAction =
+  | { type: 'continue'; nextState: IdlePollState }
+  | { type: 'shutdown' }
+  | { type: 'crash-exit'; failures: number }
+
+/**
+ * Pure evaluation of a single idle-monitor poll tick.
+ *
+ * Caller supplies the fetch result and current state;
+ * function returns the action and updated state.
+ */
+export function evaluateIdlePoll(
+  fetchResult: { ok: true; activePages: number } | { ok: false },
+  state: IdlePollState,
+  config: { idleTimeoutMs: number; maxConsecutiveFailures: number },
+  now: number = Date.now()
+): IdlePollAction {
+  if (!fetchResult.ok) {
+    const failures = state.consecutiveFailures + 1
+    if (failures >= config.maxConsecutiveFailures) {
+      return { type: 'crash-exit', failures }
+    }
+    return {
+      type: 'continue',
+      nextState: { ...state, consecutiveFailures: failures }
+    }
+  }
+
+  // Success — reset failure counter
+  if (fetchResult.activePages > 0) {
+    return {
+      type: 'continue',
+      nextState: { idleStartedAt: null, consecutiveFailures: 0 }
+    }
+  }
+
+  // No active pages — start or continue idle countdown
+  const idleStartedAt = state.idleStartedAt ?? now
+  if (now - idleStartedAt >= config.idleTimeoutMs) {
+    return { type: 'shutdown' }
+  }
+
+  return {
+    type: 'continue',
+    nextState: { idleStartedAt, consecutiveFailures: 0 }
+  }
+}

--- a/executor-node/test/browser-args.test.ts
+++ b/executor-node/test/browser-args.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { chromiumArgs } from '../src/browser-args.js'
+
+describe('chromiumArgs', () => {
+  afterEach(() => {
+    delete process.env.QUARRY_NO_SANDBOX
+  })
+
+  it('always includes --disable-dev-shm-usage', () => {
+    expect(chromiumArgs()).toContain('--disable-dev-shm-usage')
+  })
+
+  it('includes --disable-dev-shm-usage first', () => {
+    expect(chromiumArgs()[0]).toBe('--disable-dev-shm-usage')
+  })
+
+  it('does not include sandbox flags by default', () => {
+    const args = chromiumArgs()
+    expect(args).not.toContain('--no-sandbox')
+    expect(args).not.toContain('--disable-setuid-sandbox')
+  })
+
+  it('includes sandbox flags when QUARRY_NO_SANDBOX=1', () => {
+    process.env.QUARRY_NO_SANDBOX = '1'
+    const args = chromiumArgs()
+    expect(args).toContain('--no-sandbox')
+    expect(args).toContain('--disable-setuid-sandbox')
+  })
+
+  it('passes through extra args', () => {
+    const args = chromiumArgs(['--proxy-server=http://proxy:8080'])
+    expect(args).toContain('--proxy-server=http://proxy:8080')
+    expect(args).toContain('--disable-dev-shm-usage')
+  })
+
+  it('preserves extra args order after --disable-dev-shm-usage', () => {
+    const args = chromiumArgs(['--proxy-server=http://proxy:8080'])
+    expect(args.indexOf('--disable-dev-shm-usage')).toBeLessThan(
+      args.indexOf('--proxy-server=http://proxy:8080')
+    )
+  })
+})

--- a/executor-node/test/browser-idle.test.ts
+++ b/executor-node/test/browser-idle.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateIdlePoll, type IdlePollState } from '../src/browser-idle.js'
+
+const defaultConfig = { idleTimeoutMs: 60_000, maxConsecutiveFailures: 3 }
+
+function freshState(): IdlePollState {
+  return { idleStartedAt: null, consecutiveFailures: 0 }
+}
+
+describe('evaluateIdlePoll', () => {
+  describe('transient failure retry', () => {
+    it('survives 1 failure — continues with incremented counter', () => {
+      const action = evaluateIdlePoll({ ok: false }, freshState(), defaultConfig)
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.consecutiveFailures).toBe(1)
+      }
+    })
+
+    it('survives 2 consecutive failures — continues', () => {
+      const state: IdlePollState = { idleStartedAt: null, consecutiveFailures: 1 }
+      const action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.consecutiveFailures).toBe(2)
+      }
+    })
+
+    it('exits on 3 consecutive failures', () => {
+      const state: IdlePollState = { idleStartedAt: null, consecutiveFailures: 2 }
+      const action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+
+      expect(action.type).toBe('crash-exit')
+      if (action.type === 'crash-exit') {
+        expect(action.failures).toBe(3)
+      }
+    })
+
+    it('resets failure counter on success after failures', () => {
+      const state: IdlePollState = { idleStartedAt: null, consecutiveFailures: 2 }
+      const action = evaluateIdlePoll({ ok: true, activePages: 1 }, state, defaultConfig)
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.consecutiveFailures).toBe(0)
+      }
+    })
+
+    it('2 failures then success then 2 failures survives (no accumulation)', () => {
+      let state = freshState()
+
+      // Fail twice
+      let action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+      expect(action.type).toBe('continue')
+      state = (action as { type: 'continue'; nextState: IdlePollState }).nextState
+
+      action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+      expect(action.type).toBe('continue')
+      state = (action as { type: 'continue'; nextState: IdlePollState }).nextState
+      expect(state.consecutiveFailures).toBe(2)
+
+      // Succeed — resets counter
+      action = evaluateIdlePoll({ ok: true, activePages: 1 }, state, defaultConfig)
+      expect(action.type).toBe('continue')
+      state = (action as { type: 'continue'; nextState: IdlePollState }).nextState
+      expect(state.consecutiveFailures).toBe(0)
+
+      // Fail twice more — still alive
+      action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+      state = (action as { type: 'continue'; nextState: IdlePollState }).nextState
+      action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+      expect(action.type).toBe('continue')
+    })
+  })
+
+  describe('non-OK HTTP counts as failure', () => {
+    it('non-OK response increments failure count', () => {
+      // The caller wraps fetch errors (including non-OK throws) as { ok: false }
+      const action = evaluateIdlePoll({ ok: false }, freshState(), defaultConfig)
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.consecutiveFailures).toBe(1)
+      }
+    })
+
+    it('3 consecutive non-OK responses trigger crash-exit', () => {
+      let state = freshState()
+      for (let i = 0; i < 2; i++) {
+        const action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+        state = (action as { type: 'continue'; nextState: IdlePollState }).nextState
+      }
+      const action = evaluateIdlePoll({ ok: false }, state, defaultConfig)
+      expect(action.type).toBe('crash-exit')
+    })
+  })
+
+  describe('idle timeout behavior', () => {
+    it('starts idle timer when no active pages', () => {
+      const now = 1_000_000
+      const action = evaluateIdlePoll(
+        { ok: true, activePages: 0 },
+        freshState(),
+        defaultConfig,
+        now
+      )
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.idleStartedAt).toBe(now)
+      }
+    })
+
+    it('resets idle timer when active pages found', () => {
+      const state: IdlePollState = { idleStartedAt: 1_000_000, consecutiveFailures: 0 }
+      const action = evaluateIdlePoll({ ok: true, activePages: 1 }, state, defaultConfig)
+
+      expect(action.type).toBe('continue')
+      if (action.type === 'continue') {
+        expect(action.nextState.idleStartedAt).toBeNull()
+      }
+    })
+
+    it('continues when idle but timeout not reached', () => {
+      const state: IdlePollState = { idleStartedAt: 1_000_000, consecutiveFailures: 0 }
+      const action = evaluateIdlePoll(
+        { ok: true, activePages: 0 },
+        state,
+        defaultConfig,
+        1_030_000 // 30s elapsed, timeout is 60s
+      )
+
+      expect(action.type).toBe('continue')
+    })
+
+    it('shuts down when idle timeout exceeded', () => {
+      const state: IdlePollState = { idleStartedAt: 1_000_000, consecutiveFailures: 0 }
+      const action = evaluateIdlePoll(
+        { ok: true, activePages: 0 },
+        state,
+        defaultConfig,
+        1_060_000 // exactly 60s elapsed
+      )
+
+      expect(action.type).toBe('shutdown')
+    })
+
+    it('shuts down when idle timeout exceeded by margin', () => {
+      const state: IdlePollState = { idleStartedAt: 1_000_000, consecutiveFailures: 0 }
+      const action = evaluateIdlePoll(
+        { ok: true, activePages: 0 },
+        state,
+        defaultConfig,
+        1_065_000 // 65s elapsed
+      )
+
+      expect(action.type).toBe('shutdown')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Chrome renderer processes communicate via `/dev/shm`. In containerized environments with limited shared memory (e.g., Docker default 64MB, or 256MB with concurrent batches), shm exhaustion crashes Chrome IPC — new executors can't connect to the browser within the 30s timeout, causing a cascade of `executor_crash` failures. Additionally, the browser server's idle monitoring loop exits on a single transient `/json/list` failure with no retry tolerance.

## Highlights

- Add `--disable-dev-shm-usage` to all three Chromium launch sites (`browserServer`, `launchBrowserServer`, regular executor) — Chrome uses `/tmp` instead of `/dev/shm` for IPC, eliminating shm exhaustion as a crash vector
- Add retry tolerance (3 consecutive failures required) to the `/json/list` idle monitoring loop — a single transient fetch failure no longer kills the browser server process
- Log the failure count on exit for observability (`Browser health check failed N times consecutively, exiting`)
- Rebuild executor bundle

## Test plan

- [x] `npx tsc --noEmit` in executor-node/ — type-checks clean
- [x] `npx @biomejs/biome check executor-node/src/bin/executor.ts` — lint clean
- [x] `task executor:bundle` — bundle rebuilt successfully
- [x] `go test ./runtime/ -count=1` — all runtime tests pass
- [ ] Deploy to container environment and verify batch runs no longer cascade-crash under concurrent load

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)