### PR TITLE
fix(sdk): 🎨 fix Biome formatting in proxy validation

### DIFF
--- a/sdk/src/proxy.ts
+++ b/sdk/src/proxy.ts
@@ -70,7 +70,9 @@ export function validateProxyEndpoint(endpoint: ProxyEndpoint, prefix = ''): Pro
 
   // Host validation (required per CONTRACT_PROXY.md)
   if (!endpoint.host || typeof endpoint.host !== 'string') {
-    errors.push(validationError(`${fieldPrefix}host`, 'Host is required and must be a non-empty string'))
+    errors.push(
+      validationError(`${fieldPrefix}host`, 'Host is required and must be a non-empty string')
+    )
   }
 
   // Protocol validation

--- a/sdk/test/proxy.test.ts
+++ b/sdk/test/proxy.test.ts
@@ -39,9 +39,7 @@ describe('validateProxyEndpoint', () => {
   })
 
   it('valid endpoint with auth (username + password) returns valid', () => {
-    const result = validateProxyEndpoint(
-      validEndpoint({ username: 'user', password: 'pass' })
-    )
+    const result = validateProxyEndpoint(validEndpoint({ username: 'user', password: 'pass' }))
 
     expect(result.valid).toBe(true)
     expect(result.errors).toHaveLength(0)


### PR DESCRIPTION
## Summary

Auto-format `sdk/src/proxy.ts` and `sdk/test/proxy.test.ts` to satisfy Biome line-length rules introduced by the pre-release sweep (#192).

## Highlights

- Line-wrap long `errors.push(validationError(...))` call in `proxy.ts`
- Inline short `validateProxyEndpoint(...)` call in `proxy.test.ts`

## Test plan

- [x] `pnpm -C sdk lint` — clean (0 errors)
- [x] `pnpm -C sdk test` — 230/230 pass
- [x] `pnpm -C sdk typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)