### PR TITLE
chore(release): 🔖 bump lockstep version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.11.0] - 2026-02-23
+
 ### Added
 
 - **CLI**: `--dry-run` flag for script validation without execution (#191)
@@ -464,7 +468,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/pithecene-io/quarry/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/pithecene-io/quarry/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.11.0
 [0.10.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.10.0
 [0.9.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.9.0
 [0.8.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.8.0

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.10.0
+// Quarry Executor Bundle v0.11.0
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -218,7 +218,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError;
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.10.0";
+    CONTRACT_VERSION = "0.11.0";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.10.0"
+const Version = "0.11.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.10.0' as const
+export const CONTRACT_VERSION = '0.11.0' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 /** Branded type for run identifiers */

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.10.0",
+    "contract_version": "0.11.0",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Lockstep version bump from 0.10.0 to 0.11.0 per AGENTS.md version policy checklist. Single commit, all components updated atomically.

## Highlights

- `quarry/types/version.go` → `0.11.0` (Go canonical)
- `sdk/package.json` → `0.11.0` (npm version)
- `sdk/src/types/events.ts` `CONTRACT_VERSION` → `0.11.0` (SDK constant)
- Golden test fixtures (`sdk/test/emit/06-golden/*.json`) → `contract_version: "0.11.0"`
- Executor bundle rebuilt (`quarry/executor/bundle/executor.mjs`)
- CHANGELOG.md: `[Unreleased]` entries promoted to `[0.11.0] - 2026-02-23`

## Test plan

- [x] `go test ./...` — all 17 packages pass
- [x] `pnpm -C sdk test` — 230/230 pass (including golden fixture tests)
- [x] `pnpm -C executor-node test` — 200/200 pass
- [x] Executor bundle shows `Version: 0.11.0` in build output
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)