### PR TITLE
fix(release): 🐛 preserve existing release notes in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,13 +234,37 @@ jobs:
     runs-on: ubuntu-latest
     needs: [hold]
     steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
       - name: ⬇️ Download Artifacts
         uses: actions/download-artifact@v4
         with:
           name: release-dist
           path: dist
 
-      - name: 🚀 Create Release
+      - name: 🔍 Check for existing release
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          BODY=$(gh release view "$TAG" \
+            --json body -q '.body' 2>/dev/null || echo "")
+          if echo "$BODY" | grep -qv "TODO: Add release notes"; then
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_notes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 📎 Upload assets to existing release
+        if: steps.existing.outputs.has_notes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" dist/* --clobber
+
+      - name: 🚀 Create draft release
+        if: steps.existing.outputs.has_notes != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

The release workflow unconditionally set a placeholder body on every run, overwriting notes added via `gh release edit` before the workflow reached the release job. Now checks for an existing release body first and only applies the placeholder when no real notes are present.

## Highlights

- Check for existing release body before creating/updating the GitHub release
- If real notes exist (not the TODO placeholder), upload assets without touching the body
- If no notes or only the placeholder, apply the TODO placeholder as before

## Test plan

- [ ] CI passes
- [ ] Next release: set notes via `gh release edit` before workflow completes — notes should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)