### PR TITLE
fix(release): 🐛 add retry loop to JSR publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,7 +355,22 @@ jobs:
         working-directory: sdk
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          npx jsr publish --set-version "$VERSION"
+          MAX_ATTEMPTS=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "🔄 Attempt $attempt/$MAX_ATTEMPTS"
+            if npx jsr publish --set-version "$VERSION"; then
+              echo "✅ Published successfully"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "⏳ Retrying in ${DELAY}s..."
+              sleep "$DELAY"
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "❌ Failed after $MAX_ATTEMPTS attempts"
+          exit 1
 
   container:
     name: 🐳 Container Images


### PR DESCRIPTION
## Summary

JSR registry transiently fails with server-side deserialization errors (`Invalid symbol 45, offset 1246`). This has caused 2 release failures requiring manual re-runs. Add a bash retry loop with exponential backoff to handle it automatically.

## Highlights

- 3 attempts with exponential backoff (10s, 20s delay between retries)
- No new dependencies — plain bash loop
- GitHub Actions has no native step-level retry mechanism

## Test plan

- [ ] CI passes (yamllint, lint)
- [ ] Next release: JSR publish should auto-retry on transient failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)