### PR TITLE
fix(ai): 🩹 align repo-local skill schema with bonsai unified output format

### DIFF
--- a/ai/skills/repo-convention-enforcer/v1/SKILL.md
+++ b/ai/skills/repo-convention-enforcer/v1/SKILL.md
@@ -63,5 +63,14 @@ report it as ambiguity.
 
 Absence of justification is failure.
 
+Classify each finding by severity:
+- BLOCKING: hard violations that must prevent merge
+- MAJOR: significant issues that should be addressed
+- WARNING: potential concerns worth reviewing
+- INFO: observations and context
+
+Set status to "fail" if any BLOCKING findings exist, otherwise "pass".
+Set skill to "repo-convention-enforcer" and version to "v1".
+
 Output must strictly conform to output.schema.json.
 No additional text is permitted.

--- a/ai/skills/repo-convention-enforcer/v1/output.schema.json
+++ b/ai/skills/repo-convention-enforcer/v1/output.schema.json
@@ -1,28 +1,30 @@
 {
   "type": "object",
-  "required": [
-    "violations",
-    "redundancies",
-    "forbidden_exists",
-    "ambiguities"
-  ],
-  "additionalProperties": false,
+  "required": ["skill", "version", "status", "blocking", "major", "warning", "info"],
   "properties": {
-    "violations": {
+    "skill": { "type": "string" },
+    "version": { "type": "string" },
+    "status": { "type": "string", "enum": ["pass", "fail"] },
+    "blocking": {
       "type": "array",
       "items": { "type": "string" }
     },
-    "redundancies": {
+    "major": {
       "type": "array",
       "items": { "type": "string" }
     },
-    "forbidden_exists": {
+    "warning": {
       "type": "array",
       "items": { "type": "string" }
     },
-    "ambiguities": {
+    "info": {
       "type": "array",
       "items": { "type": "string" }
-    }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "details": { "type": "object" }
   }
 }


### PR DESCRIPTION
## Summary

Align the repo-local `repo-convention-enforcer` skill with bonsai's unified
output schema. The old shell-framework schema used different field names,
causing bonsai validation errors on every check run.

## Highlights

- Replace `output.schema.json` with bonsai unified schema (`skill`, `version`, `status`, `blocking`, `major`, `warning`, `info`)
- Add severity classification instructions to `SKILL.md` (BLOCKING/MAJOR/WARNING/INFO)
- Add skill identity fields (`skill`, `version`) to output instructions

## Test plan

- [x] `bonsai skill repo-convention-enforcer` produces valid JSON output
- [x] `bonsai check --bundle default` completes without `repo-convention-enforcer` error
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)