### PR TITLE
chore(repo): 🙈 gitignore .claude/ and ai/out/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ __coverage__/
 # Example run output
 .example-runs/
 
+# Claude Code local config
+.claude/
+
+# AI skill output (generated, non-authoritative)
+ai/out/
+
 # Go build output
 quarry/quarry
 


### PR DESCRIPTION
## Summary

Prevent accidental commit of machine-local Claude Code settings and generated AI skill output. Identified during bonsai review ([pithecene-io/bonsai#44](https://github.com/pithecene-io/bonsai/issues/44)).

## Highlights

- `.claude/` contains local permissions (`settings.local.json`) with broad destructive capabilities — must stay untracked
- `ai/out/` is generated skill execution output, already classified as non-authoritative in ARCH_INDEX.md
- Neither directory has tracked files today; this is a defensive measure

## Test plan

- [x] `git status` no longer shows `.claude/` or `ai/out/` as untracked
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)