### PR TITLE
feat(lode): ✨ add CAS retry on snapshot conflict via Lode v0.9.0

### DIFF
--- a/docs/contracts/CONTRACT_LODE.md
+++ b/docs/contracts/CONTRACT_LODE.md
@@ -63,6 +63,20 @@ For Hive-style layouts, the preferred order is:
 
 ---
 
+## Write Retry
+
+Quarry configures Lode with bounded CAS retry (`WithRetryCount(3)`) on the
+write path. On `ErrSnapshotConflict`, the Lode commit is retried up to 3
+times with jittered exponential backoff (10ms base, 2s max).
+
+- Data files are written once; only the manifest re-parent and pointer CAS
+  are retried.
+- Non-conflict errors are fatal (no retry).
+- The `lode_write_retry_total` metric is reserved for future use and
+  remains 0 until Lode exposes a retry callback.
+
+---
+
 ## Record Types
 
 All stored records MUST include a `record_kind` discriminator field.
@@ -158,7 +172,7 @@ Field names use the `_total` suffix to match CONTRACT_METRICS.md naming.
 | `ipc_decode_errors_total`       | int64             | yes      | Executor counter                         |
 | `lode_write_success_total`      | int64             | yes      | Storage counter                          |
 | `lode_write_failure_total`      | int64             | yes      | Storage counter                          |
-| `lode_write_retry_total`        | int64             | yes      | Storage counter (reserved)               |
+| `lode_write_retry_total`        | int64             | yes      | Storage counter (reserved; always 0 until Lode exposes retry observability) |
 | `policy`                        | string            | yes      | Dimension: policy name                   |
 | `executor`                      | string            | yes      | Dimension: executor identity             |
 | `storage_backend`               | string            | yes      | Dimension: storage backend               |

--- a/quarry/go.mod
+++ b/quarry/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
-	github.com/pithecene-io/lode v0.8.0
+	github.com/pithecene-io/lode v0.9.0
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/quarry/go.sum
+++ b/quarry/go.sum
@@ -121,8 +121,8 @@ github.com/parquet-go/parquet-go v0.27.0 h1:vHWK2xaHbj+v1DYps03yDRpEsdtOeKbhiXUa
 github.com/parquet-go/parquet-go v0.27.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
 github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
-github.com/pithecene-io/lode v0.8.0 h1:GcP8EuM+OsllsDp4GrWnzKpxjNHgnEa4Ix6bkw1rAx4=
-github.com/pithecene-io/lode v0.8.0/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
+github.com/pithecene-io/lode v0.9.0 h1:m05a/U5CLNZMkWb91AXEcNcBbRj36WRnXzkO59oZ2kc=
+github.com/pithecene-io/lode v0.9.0/go.mod h1:Qis2hes8GOnroPcYPYAXL2/RpS5KBTM+NBd8FSbK4sc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.17.3 h1:fN29NdNrE17KttK5Ndf20buqfDZwGNgoUr9qjl1DQx4=

--- a/quarry/lode/client.go
+++ b/quarry/lode/client.go
@@ -69,6 +69,7 @@ func NewLodeClientWithFactory(cfg Config, factory lode.StoreFactory) (*LodeClien
 		factory,
 		lode.WithHiveLayout("source", "category", "day", "run_id", "event_type"),
 		lode.WithCodec(lode.NewJSONLCodec()),
+		lode.WithRetryCount(3),
 	)
 	if err != nil {
 		return nil, WrapInitError(err, cfg.Dataset)

--- a/quarry/lode/client_s3.go
+++ b/quarry/lode/client_s3.go
@@ -95,6 +95,7 @@ func NewLodeS3Client(cfg Config, s3cfg S3Config) (*LodeClient, error) {
 		s3Factory,
 		lode.WithHiveLayout("source", "category", "day", "run_id", "event_type"),
 		lode.WithCodec(lode.NewJSONLCodec()),
+		lode.WithRetryCount(3),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Lode dataset: %w", err)


### PR DESCRIPTION
## Summary

Upgrade Lode from v0.8.0 to v0.9.0 and enable bounded CAS retry on the write path. Concurrent runs writing to the same partition no longer fail terminally on snapshot conflict — the commit is retried up to 3 times with jittered exponential backoff (10ms base, 2s max, full jitter).

## Highlights

- Bump `github.com/pithecene-io/lode` v0.8.0 → v0.9.0
- Add `lode.WithRetryCount(3)` to both write-path dataset constructors (FS in `client.go`, S3 in `client_s3.go`)
- Document write retry semantics in `CONTRACT_LODE.md`
- Update `lode_write_retry_total` metric description to clarify it remains reserved until Lode exposes retry observability
- No breaking changes apply: quarry uses neither `VolumeOption` nor `WithVolumeChecksum`
- Read-path dataset (`dataset.go`) unchanged — Lode rejects retry options on readers

## Test plan

- [x] `go build ./...` compiles cleanly against v0.9.0
- [x] `go test ./...` — all 18 packages pass
- [ ] CI passes
- [ ] Manual: concurrent `quarry run` to same partition no longer produces `policy_failure` on snapshot conflict

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)