### PR TITLE
chore(release): 🔖 v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.1] - 2026-03-08
+
+### Changed
+
+- **Lode**: Upgraded Lode dependency from v0.8.0 to v0.9.0 — adds opt-in CAS retry on snapshot conflict (#215)
+- **Lode**: Write-path datasets now configured with `WithRetryCount(3)` — concurrent runs to the same partition retry up to 3 times with jittered exponential backoff instead of failing terminally (#215, #213)
+- **IPC**: Reduced IPC overhead and eliminated batcher busy-wait spin loop (#205)
+- **Internal**: Extracted `iox` package for deferred-close resource cleanup helpers (#209)
+
+### Fixed
+
+- **CI**: Release workflow preserves existing release notes (#200)
+- **CI**: JSR publish step retries on transient failures (#201)
+
+---
+
 ## [0.12.0] - 2026-02-24
 
 ### Added
@@ -482,7 +498,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/pithecene-io/quarry/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/pithecene-io/quarry/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/pithecene-io/quarry/releases/tag/v0.12.1
 [0.12.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.12.0
 [0.11.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.11.0
 [0.10.0]: https://github.com/pithecene-io/quarry/releases/tag/v0.10.0

--- a/quarry/executor/bundle/executor.mjs
+++ b/quarry/executor/bundle/executor.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Quarry Executor Bundle v0.12.0
+// Quarry Executor Bundle v0.12.1
 // This is a bundled version for embedding in the quarry binary.
 // Do not edit directly - regenerate with: task executor:bundle
 
@@ -332,7 +332,7 @@ var CONTRACT_VERSION, TerminalEventError, SinkFailedError, StorageFilenameError,
 var init_dist = __esm({
   "../sdk/dist/index.mjs"() {
     "use strict";
-    CONTRACT_VERSION = "0.12.0";
+    CONTRACT_VERSION = "0.12.1";
     TerminalEventError = class extends Error {
       constructor() {
         super("Cannot emit: a terminal event (run_error or run_complete) has already been emitted");

--- a/quarry/types/version.go
+++ b/quarry/types/version.go
@@ -5,4 +5,4 @@ package types
 // per the lockstep versioning policy.
 //
 // This version is authoritative. Contract docs must reference this constant.
-const Version = "0.12.0"
+const Version = "0.12.1"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pithecene-io/quarry-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/sdk/src/types/events.ts
+++ b/sdk/src/types/events.ts
@@ -2,7 +2,7 @@
  * Event envelope and payload types per CONTRACT_EMIT.md
  */
 
-export const CONTRACT_VERSION = '0.12.0' as const
+export const CONTRACT_VERSION = '0.12.1' as const
 export type ContractVersion = typeof CONTRACT_VERSION
 
 /** Branded type for run identifiers */

--- a/sdk/test/emit/06-golden/artifact-run.json
+++ b/sdk/test/emit/06-golden/artifact-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -47,7 +47,7 @@
     }
   },
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",

--- a/sdk/test/emit/06-golden/simple-run.json
+++ b/sdk/test/emit/06-golden/simple-run.json
@@ -1,6 +1,6 @@
 [
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -17,7 +17,7 @@
     }
   },
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",
@@ -31,7 +31,7 @@
     }
   },
   {
-    "contract_version": "0.12.0",
+    "contract_version": "0.12.1",
     "event_id": "EVENT_ID_PLACEHOLDER",
     "run_id": "00000000-0000-0000-0000-000000000001",
     "job_id": "00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
## Summary

Patch release v0.12.1 — lockstep version bump with Lode v0.9.0 CAS retry, IPC performance improvements, and internal refactoring.

## Highlights

- Lockstep version bump 0.12.0 → 0.12.1 across `types/version.go`, `sdk/package.json`, `sdk/src/types/events.ts`, golden fixtures, executor bundle
- Changelog promoted: `[Unreleased]` → `[0.12.1] - 2026-03-08`
- SDK rebuilt (`pnpm exec tsdown`)
- Executor bundle rebuilt (`task executor:bundle`) — confirms v0.12.1 in output
- All Go tests pass (18 packages)
- All SDK tests pass (287 tests)

## Test plan

- [x] `go test ./...` — all pass
- [x] `pnpm test` in sdk/ — 287 tests pass
- [x] Golden fixtures updated with `contract_version: "0.12.1"`
- [x] Executor bundle output shows `Version: 0.12.1`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)