### PR TITLE
docs(release): 📝 sweep stale version references to 0.12.1

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -26,24 +26,24 @@ Quarry is **TypeScript-first** and **ESM-only**.
 ### Via mise (recommended)
 
 ```bash
-mise install github:pithecene-io/quarry@0.12.0
+mise install github:pithecene-io/quarry@0.12.1
 ```
 
 Or pin in your `mise.toml`:
 
 ```toml
 [tools]
-"github:pithecene-io/quarry" = "0.12.0"
+"github:pithecene-io/quarry" = "0.12.1"
 ```
 
 ### Via Docker
 
 ```bash
 # Full image — includes Chrome for Testing + fonts (amd64 only, recommended)
-docker pull ghcr.io/pithecene-io/quarry:0.12.0
+docker pull ghcr.io/pithecene-io/quarry:0.12.1
 
 # Slim image — no browser, multi-arch (BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.12.0-slim
+docker pull ghcr.io/pithecene-io/quarry:0.12.1-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for `docker run` and Docker Compose examples.
@@ -706,14 +706,14 @@ task build
 
 Quarry ships container images via GHCR:
 
-- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.12.0` — includes Chrome for Testing + fonts
-- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.12.0-slim` — no browser (BYO via `--browser-ws-endpoint`)
+- **Full** (amd64 only): `ghcr.io/pithecene-io/quarry:0.12.1` — includes Chrome for Testing + fonts
+- **Slim** (amd64 + arm64): `ghcr.io/pithecene-io/quarry:0.12.1-slim` — no browser (BYO via `--browser-ws-endpoint`)
 
 For `docker run`, Docker Compose, and sidecar patterns, see [docs/guides/container.md](docs/guides/container.md).
 
 ---
 
-## Known Limitations (v0.12.0)
+## Known Limitations (v0.12.1)
 
 1. **Single executor type**: Only Node.js executor supported
 2. **No built-in retries**: Retry logic is caller's responsibility
@@ -798,7 +798,7 @@ See adapter flags above.
 
 ```bash
 quarry version
-# 0.12.0 (commit: ...)
+# 0.12.1 (commit: ...)
 ```
 
 SDK and runtime versions must match (lockstep versioning).
@@ -807,8 +807,8 @@ SDK and runtime versions must match (lockstep versioning).
 
 | Component | Channel | Install |
 |-----------|---------|---------|
-| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.12.0` |
-| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.12.0` |
-| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.12.0-slim` |
+| CLI binary | GitHub Releases | `mise install github:pithecene-io/quarry@0.12.1` |
+| Container (full, amd64) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.12.1` |
+| Container (slim, multi-arch) | GHCR | `docker pull ghcr.io/pithecene-io/quarry:0.12.1-slim` |
 | SDK | JSR | `npx jsr add @pithecene-io/quarry-sdk` |
 | SDK | GitHub Packages | `pnpm add @pithecene-io/quarry-sdk` |

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Quarry executes user-authored Puppeteer scripts under a strict runtime contract,
 ### CLI
 
 ```bash
-mise install github:pithecene-io/quarry@0.12.0
+mise install github:pithecene-io/quarry@0.12.1
 ```
 
 ### Docker
 
 ```bash
 # Full image (includes Chromium + fonts)
-docker pull ghcr.io/pithecene-io/quarry:0.12.0
+docker pull ghcr.io/pithecene-io/quarry:0.12.1
 
 # Slim image (no browser — BYO Chromium via --browser-ws-endpoint)
-docker pull ghcr.io/pithecene-io/quarry:0.12.0-slim
+docker pull ghcr.io/pithecene-io/quarry:0.12.1-slim
 ```
 
 See [docs/guides/container.md](docs/guides/container.md) for Docker Compose examples.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,19 @@
-# Support Posture — Quarry v0.12.0
+# Support Posture — Quarry v0.12.1
 
-This document defines support expectations for Quarry v0.12.0.
+This document defines support expectations for Quarry v0.12.1.
 
 ---
 
 ## Maturity Level
 
-**v0.12.0 is an early release.** APIs and behaviors may change in subsequent
+**v0.12.1 is an early release.** APIs and behaviors may change in subsequent
 minor versions. Breaking changes will be documented in release notes.
 
 ---
 
 ## Known Issues
 
-_No known issues in v0.12.0._
+_No known issues in v0.12.1._
 
 ---
 
@@ -134,12 +134,12 @@ Quarry uses lockstep versioning:
 Check versions:
 ```bash
 quarry version
-# 0.12.0 (commit: ...)
+# 0.12.1 (commit: ...)
 ```
 
 ---
 
 ## No Warranty
 
-Quarry v0.12.0 is provided "as is" without warranty of any kind.
+Quarry v0.12.1 is provided "as is" without warranty of any kind.
 See LICENSE for details.

--- a/docs/CLI_PARITY.json
+++ b/docs/CLI_PARITY.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "CLI flag/config parity artifact. Machine-checkable source of truth for CLI flags.",
   "commands": {
     "run": {

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -13,8 +13,8 @@ Quarry’s core principle:
 
 Scripts and executors remain **policy-agnostic**.
 
-## Current Status (as of v0.12.0)
-- Latest release: v0.12.0 (see CHANGELOG.md).
+## Current Status (as of v0.12.1)
+- Latest release: v0.12.1 (see CHANGELOG.md).
 - Phases 0–5 complete. Phase 6 (dogfooding) in progress.
 - All v1.0 readiness items resolved (see docs/RELEASE_READINESS_v1.0.md).
 

--- a/docs/guides/container.md
+++ b/docs/guides/container.md
@@ -11,8 +11,8 @@ Quarry ships two container images via GHCR:
 
 | Image | Tag | Arch | Includes |
 |-------|-----|------|----------|
-| Full | `ghcr.io/pithecene-io/quarry:0.12.0` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
-| Slim | `ghcr.io/pithecene-io/quarry:0.12.0-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
+| Full | `ghcr.io/pithecene-io/quarry:0.12.1` | amd64 | Quarry CLI, Node.js, Puppeteer, Chrome for Testing, fonts |
+| Slim | `ghcr.io/pithecene-io/quarry:0.12.1-slim` | amd64, arm64 | Quarry CLI, Node.js, Puppeteer (no browser) |
 
 The **full** image is recommended for standalone usage. The **slim** image is
 for environments where Chromium is provided externally (e.g., via
@@ -34,7 +34,7 @@ and run as a non-root `quarry` user.
 docker run --rm \
   -v ./scripts:/work/scripts:ro \
   -v ./data:/work/data \
-  ghcr.io/pithecene-io/quarry:0.12.0 \
+  ghcr.io/pithecene-io/quarry:0.12.1 \
   run \
     --script ./scripts/my-script.ts \
     --run-id "run-$(date +%s)" \
@@ -50,7 +50,7 @@ docker run --rm \
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.12.0
+    image: ghcr.io/pithecene-io/quarry:0.12.1
     volumes:
       - ./scripts:/work/scripts:ro
       - ./data:/work/data
@@ -71,7 +71,7 @@ services:
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.12.0
+    image: ghcr.io/pithecene-io/quarry:0.12.1
     volumes:
       - ./scripts:/work/scripts:ro
     environment:
@@ -99,7 +99,7 @@ services:
       - "6379:6379"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.12.0
+    image: ghcr.io/pithecene-io/quarry:0.12.1
     depends_on:
       - redis
     volumes:
@@ -135,7 +135,7 @@ executor where to find them:
 ```yaml
 services:
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.12.0
+    image: ghcr.io/pithecene-io/quarry:0.12.1
     volumes:
       - ./scripts:/work/scripts:ro
       - ./node_modules:/work/node_modules:ro
@@ -167,7 +167,7 @@ services:
       - "9222:9222"
 
   quarry:
-    image: ghcr.io/pithecene-io/quarry:0.12.0-slim
+    image: ghcr.io/pithecene-io/quarry:0.12.1-slim
     depends_on:
       - chrome
     volumes:


### PR DESCRIPTION
## Summary

Post-release docs sweep — update all installation, container, and current-version references from 0.12.0 to 0.12.1.

## Changed files

- `README.md` — mise install, docker pull tags
- `PUBLIC_API.md` — installation, container, Known Limitations header, version output, distribution table
- `SUPPORT.md` — title, maturity, known issues, version output, warranty
- `docs/guides/container.md` — all image tags in examples
- `docs/CLI_PARITY.json` — version field
- `docs/IMPLEMENTATION_PLAN.md` — current status header

## Not changed (intentionally)

- `(v0.12.0+)` feature availability markers in PUBLIC_API.md, CONTRACT_EMIT.md, sdk/README.md — these are historical
- CHANGELOG.md `[0.12.0]` entries — historical
- RELEASE_READINESS_v1.0.md "Resolved in v0.12.0" — historical

## Test plan

- [x] Text-only changes, no code impact
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)