### PR TITLE
fix(security): 🔒 bump flatted override to 3.4.2 (prototype pollution)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "pnpm": {
     "overrides": {
-      "flatted": "3.4.0",
+      "flatted": "3.4.2",
       "minimatch@^3": "3.1.4",
       "rollup": "4.59.0",
       "basic-ftp": "5.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  flatted: 3.4.0
+  flatted: 3.4.2
   minimatch@^3: 3.1.4
   rollup: 4.59.0
   basic-ftp: 5.2.0
@@ -1107,8 +1107,8 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  flatted@3.4.0:
-    resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-in@0.1.8:
     resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
@@ -2578,7 +2578,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 4.0.18
       fflate: 0.8.2
-      flatted: 3.4.0
+      flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
@@ -2910,7 +2910,7 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  flatted@3.4.0: {}
+  flatted@3.4.2: {}
 
   for-in@0.1.8: {}
 


### PR DESCRIPTION
## Summary

Bumps `flatted` pnpm override from 3.4.0 to 3.4.2, patching prototype pollution via `parse()` in flatted ≤3.4.1.

## Highlights

- Resolves Dependabot alert #9 (high severity)
- Transitive devDependency only — no runtime impact

## Test plan

- [x] `pnpm install` resolves cleanly
- [x] Lockfile updated to flatted@3.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)